### PR TITLE
Add cyber-safeguard disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Developed and battle-tested internally at Capital One, VulnHunter is released to
 
 ---
 
+> [!WARNING]
+> **Cyber-safeguard disclaimer**
+> VulnHunter performs dual-use cybersecurity work (vulnerability discovery and exploitation). If you run it against an Anthropic account that is **not** enrolled in Anthropic's [Cyber Verification Program](https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude), real-time cyber safeguards may block requests and your usage may be flagged for cyber abuse. If you intend to use VulnHunter on Anthropic's first-party platforms (Claude API / Claude Code), we strongly recommend enrolling first via the [verification portal](https://portal.anthropic.com/programs/cvp).
+>
+> We have tested VulnHunter on [AWS Bedrock](https://aws.amazon.com/bedrock/) and can categorically confirm this flagging behavior is **not** an issue there. We are likewise **not** aware of it being a problem on other hosted solutions such as [Google Vertex AI](https://cloud.google.com/vertex-ai) (where the Cyber Verification Program is not currently offered). Regardless of platform, only use VulnHunter on code you are authorized to test and in accordance with Anthropic's [Usage Policy](https://www.anthropic.com/legal/aup).
+
+---
+
 > [!IMPORTANT]
 > **Prerequisites & Model Requirements**
 > Built and optimized for **Claude Opus** running in **[Claude Code](https://docs.claude.com/en/docs/claude-code)**. 


### PR DESCRIPTION
## Summary

Adds a `WARNING` callout near the top of `README.md` alerting users to Anthropic's real-time cyber safeguards.

- Warns that running VulnHunter's dual-use analysis against an Anthropic account **not** enrolled in the [Cyber Verification Program](https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude) may block requests and get usage flagged for cyber abuse, and links the [enrollment portal](https://portal.anthropic.com/programs/cvp).
- Confirms (based on our own testing) this flagging behavior is **not** an issue on [AWS Bedrock](https://aws.amazon.com/bedrock/), and notes we are not aware of it affecting [Google Vertex AI](https://cloud.google.com/vertex-ai) (where the program is not currently offered).
- Adds an authorized-use reminder linking Anthropic's [Usage Policy](https://www.anthropic.com/legal/aup).

All links were verified to resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)