### PR TITLE
Trim cyber-safeguard disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Developed and battle-tested internally at Capital One, VulnHunter is released to
 > **Cyber-safeguard disclaimer**
 > VulnHunter performs dual-use cybersecurity work (vulnerability discovery and exploitation). If you run it against an Anthropic account that is **not** enrolled in Anthropic's [Cyber Verification Program](https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude), real-time cyber safeguards may block requests and your usage may be flagged for cyber abuse. If you intend to use VulnHunter on Anthropic's first-party platforms (Claude API / Claude Code), we strongly recommend enrolling first via the [verification portal](https://portal.anthropic.com/programs/cvp).
 >
-> We have tested VulnHunter on [AWS Bedrock](https://aws.amazon.com/bedrock/) and can categorically confirm this flagging behavior is **not** an issue there. We are likewise **not** aware of it being a problem on other hosted solutions such as [Google Vertex AI](https://cloud.google.com/vertex-ai) (where the Cyber Verification Program is not currently offered). Regardless of platform, only use VulnHunter on code you are authorized to test and in accordance with Anthropic's [Usage Policy](https://www.anthropic.com/legal/aup).
+> Only use VulnHunter on code you are authorized to test and in accordance with Anthropic's [Usage Policy](https://www.anthropic.com/legal/aup).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Developed and battle-tested internally at Capital One, VulnHunter is released to
 > [!WARNING]
 > **Cyber-safeguard disclaimer**
 > VulnHunter performs dual-use cybersecurity work (vulnerability discovery and exploitation). If you run it against an Anthropic account that is **not** enrolled in Anthropic's [Cyber Verification Program](https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude), real-time cyber safeguards may block requests and your usage may be flagged for cyber abuse. If you intend to use VulnHunter on Anthropic's first-party platforms (Claude API / Claude Code), we strongly recommend enrolling first via the [verification portal](https://portal.anthropic.com/programs/cvp).
->
-> Only use VulnHunter on code you are authorized to test and in accordance with Anthropic's [Usage Policy](https://www.anthropic.com/legal/aup).
 
 ---
 


### PR DESCRIPTION
## Summary

Trims the cyber-safeguard disclaimer in `README.md` (added in #2) down to its core message. Removes:

- The AWS Bedrock / Google Vertex AI hosted-platform note and the "regardless of platform" phrasing.
- The authorized-use / Usage Policy reminder line.

What remains is the core warning: running VulnHunter's dual-use analysis against an Anthropic account not enrolled in the [Cyber Verification Program](https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude) may trigger real-time cyber safeguards, plus the [enrollment portal](https://portal.anthropic.com/programs/cvp) link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)