### PR TITLE
vulnhunt: capability test before dismissing a hunt disposition

### DIFF
--- a/vulnhunt/phases/phase2_shared.md
+++ b/vulnhunt/phases/phase2_shared.md
@@ -44,6 +44,13 @@ These instructions apply to ALL class-group trace agents (INJ, NAV, LOG). Read y
    - **CANDIDATE** (input #, sink file:line, vuln class) → proceeds to gates
    - **SAFE** (input #, reason: sanitized / type-constrained / not reaching sink)
    - **DESIGN-INTENT** (input #, reason: this is the application's intended function)
+   **No-match ≠ safe.** The class list is non-exhaustive; test capability, not
+   category. If attacker-controlled data gains a capability here (read/write/exec/
+   disclosure/action under attacker steering), record CANDIDATE — even with no class
+   match and no literal string interpolated. Dismiss only by citing a guard at
+   file:line that removes it; never on "no class fits," "app's purpose," or "the one
+   vector I checked (`..`) is blocked." A trace that reached a dangerous effect cannot
+   be reasoned back to SAFE.
    **Severity-context check:** Before recording a candidate's CWE, verify you
    classified under the **highest-severity context** the sink accepts. If the
    sink operates on a scheme, format, or mode selected by attacker input (URI


### PR DESCRIPTION
## What

Adds one general disposition rule to `vulnhunt/phases/phase2_shared.md` (loaded by all Phase 2 class-group agents):

> **No-match ≠ safe.** Test capability, not category. If attacker-controlled data gains a capability (read/write/exec/disclosure/action under attacker steering), record CANDIDATE — even with no class match and no literal string interpolated. Dismiss only by citing a guard at file:line; never on "no class fits," "app's purpose," or "the one vector I checked (`..`) is blocked." A trace that reached a dangerous effect cannot be reasoned back to SAFE.

+7 lines, one file.

## Why

In a cross-model evaluation of `/vulnhunt` on this codebase, the hunt stage closed **two confirmed High-severity findings** as DESIGN-INTENT / NO-MATCH because they didn't pattern-match a member of the closed injection taxonomy — in one case *after the agent's own trace had already surfaced the exploit*:

| Missed finding | How it was dismissed |
|---|---|
| Symlink-following `copytree` → arbitrary host-file disclosure (CWE-59) | scored "not really `..` traversal → no real issue" (checked one vector, not the sink's other vectors) |
| Attacker repo content steering agent `Write`/`Edit`/`Bash` (agentic prompt injection) | filed "design-intent (LLM scan session)" because no literal string is interpolated |

The root cause is a **reasoning move**, not two missing CWEs: absence of a taxonomy match was treated as evidence of safety. Enumerating more classes would just move the next miss one square over, so this fixes the disposition discipline instead — capability over category, dismissal requires a cited guard, no walking a positive trace back to SAFE.

## Cost / precision

- Loads only into the hunt subagents; no per-CWE growth.
- Raises the bar for *dismissal*, not for promotion (still requires a guard-citing rebuttal), so it should not erode precision on already-clean runs.

## Validation

Re-run `/vulnhunt`'s INJ hunt on this repo (or re-adjudicate via the eval harness) and confirm the two findings above now surface as CANDIDATEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)