### PR TITLE
Make results-dir file operations symlink-safe

### DIFF
--- a/harness/local_harness/batch/utils.py
+++ b/harness/local_harness/batch/utils.py
@@ -63,14 +63,25 @@ def collect_results(clone_base=None, upload_dir=None):
 
     for entry in sorted(os.listdir(clone_base)):
         entry_path = os.path.join(clone_base, entry)
-        if not os.path.isdir(entry_path):
+        # Skip symlinked repo entries: os.path.isdir follows symlinks, so a
+        # symlinked entry could redirect enumeration outside clone_base
+        # (CANON-18 defense-in-depth).
+        if os.path.islink(entry_path) or not os.path.isdir(entry_path):
             continue
         if "_VULNHUNT_RESULTS_" in entry:
             continue
 
+        # A results-dir whose *root* is a symlink must be skipped entirely:
+        # os.path.isdir() follows it, and shutil.copytree() would then follow
+        # the symlinked source and copy the target dir's contents (e.g.
+        # ~/.ssh) into the published upload. The ignore= callable below only
+        # drops symlinks *nested inside* a real tree, not a symlinked root
+        # (CANON-18: arbitrary host-file read).
         results_dirs = [
             d for d in os.listdir(entry_path)
-            if os.path.isdir(os.path.join(entry_path, d)) and "_VULNHUNT_RESULTS_" in d
+            if "_VULNHUNT_RESULTS_" in d
+            and not os.path.islink(os.path.join(entry_path, d))
+            and os.path.isdir(os.path.join(entry_path, d))
         ]
 
         if not results_dirs:

--- a/harness/local_harness/batch/utils.py
+++ b/harness/local_harness/batch/utils.py
@@ -13,6 +13,18 @@ from local_harness.config import (
 from local_harness.scan import extract_cost_from_log
 
 
+def _ignore_symlinks(dirpath, names):
+    """copytree ignore callable that drops any symlink entry.
+
+    Cloned repos are untrusted; a planted symlink (e.g. secret -> /etc/passwd)
+    would otherwise have its target's contents copied into the published upload
+    (CANON-18: arbitrary host-file read). Called per-directory, so nested
+    symlinks are handled too. Dropping the entry entirely means neither the
+    symlink nor a dangling link ships.
+    """
+    return [name for name in names if os.path.islink(os.path.join(dirpath, name))]
+
+
 def parse_repo_list(repo_list_file=None):
     """Read REPO_LIST.txt and return list of URLs.
 
@@ -70,7 +82,7 @@ def collect_results(clone_base=None, upload_dir=None):
             dst = os.path.join(upload_dir, rdir)
             if os.path.isdir(dst):
                 shutil.rmtree(dst)
-            shutil.copytree(src, dst)
+            shutil.copytree(src, dst, ignore=_ignore_symlinks)
             copied.append(rdir)
 
     print(f"{'=' * 60}")

--- a/harness/local_harness/scan.py
+++ b/harness/local_harness/scan.py
@@ -70,6 +70,22 @@ def has_valid_results(clone_dir):
     return os.path.isfile(readme) and os.path.getsize(readme) > 100
 
 
+def _remove_results_entry(path):
+    """Remove a results entry safely.
+
+    An untrusted cloned repo can plant a symlink named *_VULNHUNT_RESULTS_*
+    pointing at a directory. os.path.isdir follows symlinks, so the old cleanup
+    code reached shutil.rmtree(<symlink>), which raises
+    "Cannot call rmtree on a symbolic link" — an unhandled OSError that aborts
+    the entire scan/batch run (CANON-34, availability DoS). Unlink the planted
+    symlink (never its target); only rmtree real directories.
+    """
+    if os.path.islink(path):
+        os.unlink(path)
+    elif os.path.isdir(path):
+        shutil.rmtree(path)
+
+
 def clean_incomplete_results(clone_dir, log_filename="benchmark_scan.log"):
     """Remove results dirs that lack a valid README.md so a resume will re-scan them.
 
@@ -81,11 +97,14 @@ def clean_incomplete_results(clone_dir, log_filename="benchmark_scan.log"):
     for entry in os.listdir(clone_dir):
         if "_VULNHUNT_RESULTS_" in entry:
             full_path = os.path.join(clone_dir, entry)
-            if not os.path.isdir(full_path):
+            is_link = os.path.islink(full_path)
+            if not is_link and not os.path.isdir(full_path):
                 continue
+            # A planted symlink is never a valid results dir; remove it (safely,
+            # without following it) so a resume re-scans cleanly.
             readme = os.path.join(full_path, "README.md")
-            if not (os.path.isfile(readme) and os.path.getsize(readme) > 100):
-                shutil.rmtree(full_path)
+            if is_link or not (os.path.isfile(readme) and os.path.getsize(readme) > 100):
+                _remove_results_entry(full_path)
                 removed.append(entry)
                 log_file = os.path.join(clone_dir, log_filename)
                 if os.path.isfile(log_file):
@@ -104,8 +123,8 @@ def clean_prior_results(clone_dir, log_filename="benchmark_scan.log"):
     for entry in os.listdir(clone_dir):
         if "_VULNHUNT_RESULTS_" in entry:
             full_path = os.path.join(clone_dir, entry)
-            if os.path.isdir(full_path):
-                shutil.rmtree(full_path)
+            if os.path.islink(full_path) or os.path.isdir(full_path):
+                _remove_results_entry(full_path)
                 removed.append(entry)
     log_file = os.path.join(clone_dir, log_filename)
     if os.path.isfile(log_file):

--- a/harness/tests/test_batch_utils.py
+++ b/harness/tests/test_batch_utils.py
@@ -97,6 +97,31 @@ def test_collect_results_does_not_follow_symlinks(tmp_path):
     assert (dst / "README.md").read_text() == "legit report"
 
 
+def test_collect_results_does_not_follow_symlinked_results_root(tmp_path):
+    # CANON-18 (source-root vector): the *_VULNHUNT_RESULTS_* dir itself is a
+    # symlink pointing at a sensitive host directory. os.path.isdir() follows
+    # it, so it must be rejected before copytree — otherwise copytree follows
+    # the symlinked source and copies the target dir's files into the upload.
+    secret_dir = tmp_path / "victim_home_ssh"
+    secret_dir.mkdir()
+    (secret_dir / "id_rsa").write_text("PRIVATE-KEY-HOST-CONTENT-xyz789")
+
+    base = tmp_path / "repos"
+    base.mkdir()
+    repo = base / "evilrepo"
+    repo.mkdir()
+    # results-dir root is a symlink to the sensitive directory
+    os.symlink(str(secret_dir), str(repo / "evilrepo_VULNHUNT_RESULTS_2"))
+
+    upload = tmp_path / "up"
+    utils.collect_results(clone_base=str(base), upload_dir=str(upload))
+
+    dst = upload / "evilrepo_VULNHUNT_RESULTS_2"
+    leaked = dst / "id_rsa"
+    assert not (leaked.exists() or os.path.lexists(str(leaked))), \
+        "symlinked results-dir root followed: host secret copied into upload"
+
+
 def test_scan_status_no_clone_base(tmp_path):
     out = utils.scan_status(clone_base=str(tmp_path / "nope"))
     assert out == {"complete": [], "errored": [], "running": [], "not_started": []}

--- a/harness/tests/test_batch_utils.py
+++ b/harness/tests/test_batch_utils.py
@@ -91,8 +91,15 @@ def test_collect_results_does_not_follow_symlinks(tmp_path):
     # Secret target contents must never appear in the published tree.
     assert not (leaked.is_file() and not leaked.is_symlink()), \
         "symlink target followed: host secret copied into upload"
-    if leaked.exists() or os.path.lexists(str(leaked)):
+    # Guard read_text(): on a dangling-link regression lexists() is True but
+    # is_file() is False, so read_text() would raise FileNotFoundError and turn
+    # a clean failure into a test error. Only read a real regular file; any
+    # surviving symlink (dangling or not) is itself an assert failure.
+    if leaked.is_file():
         assert "TOP-SECRET-HOST-CONTENT" not in leaked.read_text()
+    else:
+        assert not os.path.lexists(str(leaked)), \
+            "symlink shipped into upload (dangling or otherwise)"
     # The legitimate regular file still copies fine.
     assert (dst / "README.md").read_text() == "legit report"
 
@@ -120,6 +127,51 @@ def test_collect_results_does_not_follow_symlinked_results_root(tmp_path):
     leaked = dst / "id_rsa"
     assert not (leaked.exists() or os.path.lexists(str(leaked))), \
         "symlinked results-dir root followed: host secret copied into upload"
+
+
+def test_collect_results_does_not_follow_deep_nested_symlinked_subdir(tmp_path):
+    # CANON-18 (deep-nested vector): the results dir is a real tree several
+    # levels deep, and at a deep leaf sits a symlink to a DIRECTORY outside the
+    # tree holding a secret. copytree's per-directory ignore= callable must drop
+    # the symlinked subdir *before* recursing into it, so neither the linked
+    # directory nor its secret contents ship. This locks in that the fix walks
+    # the whole tree, not just the top level.
+    secret_dir = tmp_path / "outside_secret_dir"
+    secret_dir.mkdir()
+    (secret_dir / "creds.env").write_text("AWS_SECRET_ACCESS_KEY=DEEP-NESTED-SECRET-qq42")
+
+    base = tmp_path / "repos"
+    base.mkdir()
+    repo = base / "evilrepo"
+    repo.mkdir()
+    rd = repo / "evilrepo_VULNHUNT_RESULTS_3"
+    rd.mkdir()
+    # A real, several-levels-deep subtree of legitimate content.
+    deep = rd / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    (deep / "finding.md").write_text("legit deep finding")
+    # At the deep leaf, plant a symlink to the outside secret DIRECTORY.
+    os.symlink(str(secret_dir), str(deep / "linked_dir"))
+
+    upload = tmp_path / "up"
+    utils.collect_results(clone_base=str(base), upload_dir=str(upload))
+
+    dst = upload / "evilrepo_VULNHUNT_RESULTS_3"
+    # The legitimate deep tree ships intact.
+    assert (dst / "a" / "b" / "c" / "finding.md").read_text() == "legit deep finding"
+    # The symlinked subdir must not ship at all (not even as a dangling link).
+    linked_upload = dst / "a" / "b" / "c" / "linked_dir"
+    assert not os.path.lexists(str(linked_upload)), \
+        "deep-nested symlinked subdir shipped into upload"
+    # The secret's contents must appear nowhere under the upload dir.
+    for root, _dirs, files in os.walk(str(upload)):
+        for name in files:
+            fp = os.path.join(root, name)
+            if os.path.islink(fp) or not os.path.isfile(fp):
+                continue
+            with open(fp, "r", errors="ignore") as f:
+                assert "DEEP-NESTED-SECRET" not in f.read(), \
+                    f"secret leaked into upload at {fp}"
 
 
 def test_scan_status_no_clone_base(tmp_path):

--- a/harness/tests/test_batch_utils.py
+++ b/harness/tests/test_batch_utils.py
@@ -1,6 +1,7 @@
 """Tests for local_harness.batch.utils."""
 
 import json
+import os
 
 import local_harness.batch.utils as utils
 
@@ -64,6 +65,36 @@ def test_collect_results_overwrites_existing_dst(tmp_path):
     utils.collect_results(clone_base=str(base), upload_dir=str(upload))
     assert not (upload / "repoA_VULNHUNT_RESULTS_1" / "OLD.md").exists()
     assert (upload / "repoA_VULNHUNT_RESULTS_1" / "README.md").exists()
+
+
+def test_collect_results_does_not_follow_symlinks(tmp_path):
+    # CANON-18: a scanned (untrusted) repo can plant a symlink inside its
+    # *_VULNHUNT_RESULTS_* dir pointing at a sensitive host file. collect_results
+    # must not follow it and copy the target's contents into the published upload.
+    secret = tmp_path / "SECRET_host_file"
+    secret.write_text("TOP-SECRET-HOST-CONTENT-abc123")
+
+    base = tmp_path / "repos"
+    base.mkdir()
+    repo = base / "evilrepo"
+    repo.mkdir()
+    rd = repo / "evilrepo_VULNHUNT_RESULTS_1"
+    rd.mkdir()
+    (rd / "README.md").write_text("legit report")
+    os.symlink(str(secret), str(rd / "stolen_passwd"))
+
+    upload = tmp_path / "up"
+    utils.collect_results(clone_base=str(base), upload_dir=str(upload))
+
+    dst = upload / "evilrepo_VULNHUNT_RESULTS_1"
+    leaked = dst / "stolen_passwd"
+    # Secret target contents must never appear in the published tree.
+    assert not (leaked.is_file() and not leaked.is_symlink()), \
+        "symlink target followed: host secret copied into upload"
+    if leaked.exists() or os.path.lexists(str(leaked)):
+        assert "TOP-SECRET-HOST-CONTENT" not in leaked.read_text()
+    # The legitimate regular file still copies fine.
+    assert (dst / "README.md").read_text() == "legit report"
 
 
 def test_scan_status_no_clone_base(tmp_path):

--- a/harness/tests/test_scan.py
+++ b/harness/tests/test_scan.py
@@ -101,6 +101,44 @@ def test_clean_prior_results_missing_dir(tmp_path):
     assert scan.clean_prior_results(str(tmp_path / "nope")) == []
 
 
+def test_clean_prior_results_symlink_to_dir_no_crash(tmp_path):
+    # CANON-34: an untrusted clone can plant a symlink named
+    # *_VULNHUNT_RESULTS_* pointing at a directory. os.path.isdir follows the
+    # link so the old code reached shutil.rmtree(symlink) -> OSError, aborting
+    # the whole scan (DoS). Cleanup must remove the link (not its target)
+    # without raising.
+    target = tmp_path / "real_target_dir"
+    target.mkdir()
+    (target / "keep.txt").write_text("do not delete me")
+
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    link = clone / "evil_VULNHUNT_RESULTS_1"
+    os.symlink(str(target), str(link))
+
+    removed = scan.clean_prior_results(str(clone))  # must not raise
+    assert not os.path.lexists(str(link)), "planted symlink was not removed"
+    assert target.is_dir() and (target / "keep.txt").exists(), \
+        "symlink target must be left intact (only the link is removed)"
+
+
+def test_clean_incomplete_results_symlink_to_dir_no_crash(tmp_path):
+    # CANON-34 companion: same DoS applies to clean_incomplete_results.
+    target = tmp_path / "real_target_dir"
+    target.mkdir()
+    (target / "keep.txt").write_text("do not delete me")
+
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    link = clone / "evil_VULNHUNT_RESULTS_1"
+    os.symlink(str(target), str(link))
+
+    scan.clean_incomplete_results(str(clone))  # must not raise
+    assert not os.path.lexists(str(link)), "planted symlink was not removed"
+    assert target.is_dir() and (target / "keep.txt").exists(), \
+        "symlink target must be left intact (only the link is removed)"
+
+
 # --- log inspection ---
 
 def test_is_rate_limit_failure_no_file():

--- a/vulnhunter-agent/agent/config.py
+++ b/vulnhunter-agent/agent/config.py
@@ -780,6 +780,7 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
                 else []
             )
             if str(p).strip()
+        ),
         max_comment_pages=int(
             _resolve(verify_raw, "verify", "max_comment_pages", kind=int, default=20)
         ),

--- a/vulnhunter-agent/tests/test_config.py
+++ b/vulnhunter-agent/tests/test_config.py
@@ -504,3 +504,22 @@ retries = false
         cfg = load_config(path)
         assert cfg.logging.per_turn_usage is True
         assert cfg.logging.retries is False
+
+
+class TestModuleImportable:
+    """Regression: the agent.config module must parse and expose load_config.
+
+    A prior syntax error (an unclosed VerifyConfig(token_path_prefixes=...)
+    generator) prevented the whole agent package from importing.
+    """
+
+    def test_agent_config_imports(self) -> None:
+        import importlib
+
+        module = importlib.import_module("agent.config")
+        assert module is not None
+
+    def test_load_config_is_callable(self) -> None:
+        import agent.config
+
+        assert callable(agent.config.load_config)


### PR DESCRIPTION
## Make results-dir file operations symlink-safe

Two related changes so symlinks inside a scanned repo's results directories are handled safely rather than followed, plus the same small `config.py` prerequisite build fix carried by the other branches. From the cross-model `/vulnhunt` evaluation (`eval_rep/`); developed test-first with the suites kept green.

### Prerequisite — `config.py` currently doesn't parse
Commit `5f34ec0`. `vulnhunter-agent/agent/config.py` has an unclosed paren — the `token_path_prefixes=tuple(...)` generator is missing its `),` before `max_comment_pages=int(` — so `import agent.config` raises `SyntaxError` and the agent package can't be imported. Adds the missing `),` and a small regression test (`tests/test_config.py`).
> This one-line prerequisite also appears on the other three `vulnfix/*` branches; whichever merges first applies it.

### CANON-18 — Don't follow symlinks when collecting results (CWE-59/CWE-22)
Commits `eb93671`, `823c303`. `harness/local_harness/batch/utils.py` copies results dirs with `shutil.copytree(src, dst)` and no `symlinks=` argument, so symlinks in the (untrusted) source are followed and their targets copied into the published output. Two vectors are closed:
- **Nested symlinks** (`eb93671`): an `ignore=` callable drops symlink entries, applied per-directory by `copytree`, so a symlink nested inside a real results tree is not followed.
- **Symlinked results-dir root** (`823c303`): the results-dir selection now skips entries where `os.path.islink()` is true (and symlinked repo entries) before `copytree` runs — `os.path.isdir()` follows symlinks, so without this a `*_VULNHUNT_RESULTS_*` entry that is *itself* a symlink would have its target directory's contents copied out. *(This second vector was found by an independent `vulnhunt-fix-verify` pass on the first commit and fixed in the follow-up.)*
- **Tests:** `harness/tests/test_batch_utils.py::test_collect_results_does_not_follow_symlinks` (nested) and `::test_collect_results_does_not_follow_symlinked_results_root` (root). Both fail on the unguarded code, pass after.

### CANON-34 — Handle symlinks during results-dir cleanup (CWE-754)
Commit `20a3b07`. In `harness/local_harness/scan.py`, `clean_incomplete_results` and `clean_prior_results` call `shutil.rmtree` after an `os.path.isdir` check. `isdir` follows symlinks, so a symlink-to-directory reaches `rmtree`, which raises `OSError` and aborts the run.
- **Change:** add a small shared helper `_remove_results_entry(path)` — `os.path.islink` → `os.unlink`, else `os.path.isdir` → `shutil.rmtree` — and use it at both sites, so a planted symlink is removed safely instead of crashing.
- **Test:** `harness/tests/test_scan.py` — cleanup over a symlinked results entry no longer raises, removes the link, and leaves the link's target intact. Fails on current code, passes after.

### Verification
- `harness`: 161 passed
- Discrimination evidence recorded for both findings; both re-checked FIXED by an independent `vulnhunt-fix-verify` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
