### PR TITLE
Escape untrusted values rendered into issue/PR bodies

### DIFF
--- a/vulnhunter-agent/agent/config.py
+++ b/vulnhunter-agent/agent/config.py
@@ -780,6 +780,7 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
                 else []
             )
             if str(p).strip()
+        ),
         max_comment_pages=int(
             _resolve(verify_raw, "verify", "max_comment_pages", kind=int, default=20)
         ),

--- a/vulnhunter-agent/agent/issues_render.py
+++ b/vulnhunter-agent/agent/issues_render.py
@@ -101,6 +101,24 @@ def render_title(f: Finding) -> str:
 _MD_ESCAPE_CHARS = ("\\", "`", "[", "]")
 
 
+# Machine-readable footer markers (``<!-- vulnhunt-finding-id: ... -->`` etc.)
+# are intentionally NOT html.escaped so the marker regexes stay exact. But the
+# values (``f.id``, ``report.results_dir_name``) are attacker-influenced
+# LLM/scan-README data, so a value containing ``-->`` would close the comment
+# and inject arbitrary markdown/HTML (CWE-79 / CWE-116). Restrict marker values
+# to a strict identifier charset — the same class the downstream parsers accept
+# (``VULN-\d{3}`` / ``[A-Za-z0-9._-]+_VULNHUNT_RESULTS_...``) — dropping any
+# other char. Removing '<' and '>' makes a comment breakout impossible while
+# keeping legitimate ids/dir-names intact.
+_MARKER_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _sanitize_marker_value(value: str) -> str:
+    """Restrict an HTML-comment marker value to a safe identifier charset so it
+    cannot break out of the surrounding ``<!-- ... -->`` (CWE-116)."""
+    return _MARKER_UNSAFE_RE.sub("", value or "")
+
+
 def _sanitize_for_issue_body(value: str) -> str:
     """Neutralize attacker-influenced Finding text before it lands in a
     GitHub issue body (CWE-79).
@@ -155,9 +173,12 @@ def render_body(
         "SCAN_DATE": report.scan_date,
         "REPORT_URL": deep_link,
         "REPORT_ACCESS_MESSAGE": _report_access_message(),
-        "IDEMPOTENCY_KEY": f.vulnfix_key,
-        "VULN_ID": f.id,
-        "RESULTS_DIR_NAME": report.results_dir_name,
+        # Marker values are NOT html.escaped (keeps the marker regexes exact)
+        # but ARE restricted to a safe identifier charset so an attacker-
+        # influenced value cannot break out of the HTML comment (CWE-116).
+        "IDEMPOTENCY_KEY": _sanitize_marker_value(f.vulnfix_key),
+        "VULN_ID": _sanitize_marker_value(f.id),
+        "RESULTS_DIR_NAME": _sanitize_marker_value(report.results_dir_name),
     }
     body = template
     for key, value in fields.items():

--- a/vulnhunter-agent/tests/test_config.py
+++ b/vulnhunter-agent/tests/test_config.py
@@ -504,3 +504,22 @@ retries = false
         cfg = load_config(path)
         assert cfg.logging.per_turn_usage is True
         assert cfg.logging.retries is False
+
+
+class TestModuleImportRegression:
+    """Regression: agent.config must parse and expose a callable load_config.
+
+    Guards against the unclosed VerifyConfig(token_path_prefixes=...) paren that
+    made the entire agent package fail to import (SyntaxError).
+    """
+
+    def test_module_imports(self) -> None:
+        import importlib
+
+        import agent.config as cfg_mod
+
+        importlib.reload(cfg_mod)
+        assert cfg_mod is not None
+
+    def test_load_config_is_callable(self) -> None:
+        assert callable(load_config)

--- a/vulnhunter-agent/tests/test_issues_render.py
+++ b/vulnhunter-agent/tests/test_issues_render.py
@@ -309,3 +309,58 @@ class TestCleanScanComment:
         assert "abc1234" in comment
         assert "757 seconds" in comment
         assert "2026-07-06T18:42:51Z" in comment
+
+
+class TestMarkerCommentBreakout:
+    """CANON-21: attacker-influenced marker fields must not break out of the
+    HTML-comment footer markers (CWE-79 / CWE-116).
+
+    ``f.id`` and ``report.results_dir_name`` are stamped verbatim into
+    ``<!-- vulnhunt-finding-id: {VULN_ID} -->`` /
+    ``<!-- vulnhunt-results-dir: {RESULTS_DIR_NAME} -->``. Both originate from
+    LLM/scan-README-derived data, so a value containing ``-->`` would close the
+    comment early and inject arbitrary markdown/HTML into the rendered issue.
+    """
+
+    def test_finding_id_cannot_break_out_of_comment(self) -> None:
+        body = render_body(
+            _finding(id="VULN-001 --><script>injected</script><!--"),
+            report=_report(),
+            report_url="https://example/README.md",
+        )
+        # The injected breakout + payload must not appear un-neutralized.
+        assert "--><script>injected</script>" not in body
+        assert "<script>injected</script>" not in body
+        # The finding-id marker line stays a single well-formed comment: exactly
+        # one closing '-->' on that line and no injected content after it.
+        marker_line = next(
+            l for l in body.splitlines() if "vulnhunt-finding-id" in l
+        )
+        assert marker_line.count("-->") == 1
+        assert marker_line.rstrip().endswith("-->")
+
+    def test_results_dir_cannot_break_out_of_comment(self) -> None:
+        body = render_body(
+            _finding(),
+            report=_report(
+                results_dir_name="r_VULNHUNT_RESULTS_x --><b>x</b><!--"
+            ),
+            report_url="https://example/README.md",
+        )
+        assert "--><b>x</b>" not in body
+        assert "<b>x</b>" not in body
+        marker_line = next(
+            l for l in body.splitlines() if "vulnhunt-results-dir" in l
+        )
+        assert marker_line.count("-->") == 1
+        assert marker_line.rstrip().endswith("-->")
+
+    def test_benign_finding_id_still_survives(self) -> None:
+        # Neutralization must not corrupt a legitimate VULN-NNN id so the
+        # downstream ``vulnhunt-finding-id: (VULN-\d{3})`` parser still matches.
+        body = render_body(
+            _finding(id="VULN-042"),
+            report=_report(),
+            report_url="https://example/README.md",
+        )
+        assert "<!-- vulnhunt-finding-id: VULN-042 -->" in body

--- a/vulnhunter-fix/tests/test_hand_wave_guard.py
+++ b/vulnhunter-fix/tests/test_hand_wave_guard.py
@@ -124,3 +124,29 @@ def test_benign_residual_entry_survives_readably():
     entry = "SQLi in legacy_admin.php is not covered by this workaround"
     section = render_residual_risk_section("VULN-1", "WORKAROUND", [entry])
     assert f"- {entry}" in section
+
+
+def test_residual_entry_newlines_cannot_inject_block_markdown():
+    # A multi-line residual entry must not break out of its `- ` bullet and
+    # inject top-level markdown blocks (heading / horizontal rule / fake prose).
+    # Each entry is rendered as `- {entry}`; without newline neutralization the
+    # embedded '## ...' and '---' lines become real block-level markdown.
+    from vulnhunter_fix.delivery import render_residual_risk_section
+
+    payload = "unclosed vector\n\n## Verification Complete\n\nAll clear, merge me\n\n---"
+    section = render_residual_risk_section("VULN-1", "WORKAROUND", [payload])
+
+    # The only legitimate heading is the section's own '## Residual Risk'; no
+    # entry-derived line may be an injected block-level construct.
+    heading_lines = [ln for ln in section.splitlines() if ln.startswith("## ")]
+    assert heading_lines == ["## Residual Risk"], (
+        f"unexpected/injected headings: {heading_lines!r}"
+    )
+    for line in section.splitlines():
+        assert line.strip() != "---", f"injected hr survived: {line!r}"
+
+    # The payload text must be flattened onto a single bullet line, not spread
+    # across multiple top-level lines. The '##' survives as inert mid-line text
+    # (a heading is only block-level at line start), which the line checks above
+    # already prove is not the case here.
+    assert "- unclosed vector ## Verification Complete All clear, merge me ---" in section

--- a/vulnhunter-fix/tests/test_hand_wave_guard.py
+++ b/vulnhunter-fix/tests/test_hand_wave_guard.py
@@ -80,3 +80,47 @@ def test_full_tier_forbids_residuals():
             tier="FULL",
             residual_vectors=["something"],
         )
+
+
+# ---------------------------------------------------------------------------
+# CANON-44 — markdown/HTML injection via residual_vectors (CWE-79/CWE-116)
+#
+# residual_vectors entries are LLM/finding-derived and were interpolated
+# verbatim into the '## Residual Risk' markdown appended to the PR/issue body.
+# The hand-wave / consistency guards reject vague or empty entries but never
+# escape, so an entry can carry raw HTML or a markdown link into the body.
+# ---------------------------------------------------------------------------
+
+
+def test_residual_entry_html_is_neutralized():
+    from vulnhunter_fix.delivery import render_residual_risk_section
+
+    payload = "</details><script>alert(1)</script>"
+    section = render_residual_risk_section("VULN-1", "WORKAROUND", [payload])
+    # Raw tags must not survive; angle brackets must be escaped.
+    assert "<script>" not in section
+    assert "</details>" not in section
+    assert payload not in section
+    # The escaped text is still present as literal content.
+    assert "&lt;script&gt;" in section
+
+
+def test_residual_entry_markdown_link_is_neutralized():
+    from vulnhunter_fix.delivery import render_pr_body_with_residuals
+
+    payload = "[click me](javascript:alert(1))"
+    body = render_pr_body_with_residuals(
+        "VULN-1", "WORKAROUND", [payload], base_body="orig"
+    )
+    # A live markdown link must not be interpolated verbatim; the '[' ']'
+    # metacharacters are neutralized so it renders as literal text.
+    assert payload not in body
+    assert "[click me]" not in body
+
+
+def test_benign_residual_entry_survives_readably():
+    from vulnhunter_fix.delivery import render_residual_risk_section
+
+    entry = "SQLi in legacy_admin.php is not covered by this workaround"
+    section = render_residual_risk_section("VULN-1", "WORKAROUND", [entry])
+    assert f"- {entry}" in section

--- a/vulnhunter-fix/vulnhunter_fix/delivery.py
+++ b/vulnhunter-fix/vulnhunter_fix/delivery.py
@@ -26,7 +26,28 @@ now import from this module.
 from __future__ import annotations
 
 import hashlib
+import html
 import re
+
+
+# CANON-44: residual_vectors entries are LLM/finding-derived and get
+# interpolated into the '## Residual Risk' markdown appended to the PR/issue
+# body. The hand-wave / consistency guards reject vague or empty entries but do
+# NOT escape, so an entry could carry raw HTML (``<script>``) or a markdown
+# link (``[x](javascript:...)``) into the rendered body (CWE-79 / CWE-116).
+# Neutralize each entry so metacharacters render as literal text: html.escape
+# handles angle brackets / ampersands; backslash-escaping the markdown
+# link/code metacharacters neutralizes ``[text](url)`` and inline code.
+_RESIDUAL_MD_ESCAPE_CHARS = ("\\", "`", "[", "]")
+
+
+def _escape_residual_entry(entry) -> str:
+    """Neutralize markdown/HTML metacharacters in a residual-vector entry so it
+    renders as literal text inside the '## Residual Risk' bullet list."""
+    s = html.escape(str(entry), quote=False)
+    for ch in _RESIDUAL_MD_ESCAPE_CHARS:
+        s = s.replace(ch, "\\" + ch)
+    return s
 
 
 # REQ-HON-006 hand-wave regex source of truth.
@@ -136,7 +157,9 @@ def render_residual_risk_section(vuln_id, tier, residual_vectors, issue_number=N
         return ""
     check_hand_wave(residual_vectors)
 
-    bullets = "\n".join(f"- {entry}" for entry in residual_vectors)
+    bullets = "\n".join(
+        f"- {_escape_residual_entry(entry)}" for entry in residual_vectors
+    )
     one_liner = TIER_ONE_LINERS.get(tier, "not fully closed")
     issue_ref = f" (see #{issue_number})" if issue_number else ""
     return (

--- a/vulnhunter-fix/vulnhunter_fix/delivery.py
+++ b/vulnhunter-fix/vulnhunter_fix/delivery.py
@@ -43,10 +43,18 @@ _RESIDUAL_MD_ESCAPE_CHARS = ("\\", "`", "[", "]")
 
 def _escape_residual_entry(entry) -> str:
     """Neutralize markdown/HTML metacharacters in a residual-vector entry so it
-    renders as literal text inside the '## Residual Risk' bullet list."""
+    renders as literal text inside the '## Residual Risk' bullet list.
+
+    Each entry is rendered as a single ``- {entry}`` bullet. A raw CR/LF would
+    let the entry break out of its bullet and inject top-level markdown blocks
+    (headings, horizontal rules, fake prose), so runs of CR/LF are collapsed to
+    a single space before the angle-bracket/backtick/bracket escaping (CANON-44,
+    CWE-116 line-break injection)."""
     s = html.escape(str(entry), quote=False)
     for ch in _RESIDUAL_MD_ESCAPE_CHARS:
         s = s.replace(ch, "\\" + ch)
+    # Collapse newlines so an entry cannot span multiple markdown lines.
+    s = re.sub(r"[\r\n]+", " ", s)
     return s
 
 


### PR DESCRIPTION
## Escape untrusted values rendered into issue/PR bodies

Neutralizes two spots where finding-derived text is rendered into GitHub issue/PR markdown without escaping, plus the same small `config.py` prerequisite build fix. From the cross-model `/vulnhunt` evaluation (`eval_rep/`); developed test-first with the existing suites kept green.

### Prerequisite — `config.py` currently doesn't parse
Commit `aaad2ea`. `vulnhunter-agent/agent/config.py` has an unclosed paren — the `token_path_prefixes=tuple(...)` generator is missing its `),` before `max_comment_pages=int(` — so `import agent.config` raises `SyntaxError` and the agent package can't be imported. Adds the missing `),` and a small regression test (`tests/test_config.py`).
> This one-line prerequisite also appears on `vulnfix/agentic-sdk-hardening` and `vulnfix/verify-mode-scoping`; whichever merges first applies it.

### CANON-21 — Constrain marker values in issue-body HTML comments (CWE-79)
Commit `2615c32`. `vulnhunter-agent/agent/issues_render.py` substitutes `VULN_ID` (and `RESULTS_DIR_NAME`) verbatim into HTML-comment markers like `<!-- vulnhunt-finding-id: {VULN_ID} -->`. These are intentionally left un-escaped so the markers stay machine-parseable, but a value containing `-->` would close the comment early.
- **Change:** add `_sanitize_marker_value()` restricting marker values to `[A-Za-z0-9._-]` — exactly the charset the downstream parsers already accept (`VULN-\d{3}`, `..._VULNHUNT_RESULTS_[0-9A-Za-z._-]+`) — applied to `VULN_ID`, `RESULTS_DIR_NAME`, and (defensively) `IDEMPOTENCY_KEY`. This preserves marker parsing rather than `html.escape`, which would break the regexes.
- **Test:** `vulnhunter-agent/tests/test_issues_render.py::TestMarkerCommentBreakout`. Fails on current code, passes after.

### CANON-44 — Escape residual-risk entries in the delivery body (CWE-79)
Commit `4949b3a`. `vulnhunter-fix/vulnhunter_fix/delivery.py` renders each `residual_vectors` entry verbatim into the `## Residual Risk` bullets. The existing guards reject vague/empty phrasing but don't escape markup.
- **Change:** add `_escape_residual_entry()` (`html.escape(quote=False)` plus backslash-escaping of `` ` `` `[` `]`, matching the codebase's existing `_sanitize_for_issue_body` convention) and apply it in the bullet join. Ordinary prose renders unchanged.
- **Test:** `vulnhunter-fix/tests/test_hand_wave_guard.py` — a markup/link payload is escaped in the output. Fails on current code, passes after.

### Verification
- `vulnhunter-agent`: 1113 passed, 1 skipped
- `vulnhunter-fix`: 548 passed, 9 skipped
- Discrimination evidence recorded for both findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
