### PR TITLE
Harden agent capabilities/settings against untrusted scanned repos

### DIFF
--- a/harness/local_harness/batch/run.py
+++ b/harness/local_harness/batch/run.py
@@ -94,7 +94,7 @@ def cmd_scan(args):
 
     start = time.time()
     results = scan_targets(targets, max_workers=args.max_workers, log_filename=BATCH_LOG_FILENAME,
-                           readonly=args.readonly)
+                           readonly=not args.execute)
     elapsed = time.time() - start
 
     # Phase 3: Summary
@@ -142,8 +142,9 @@ def main():
                              help="Skip repos that already have a completed scan report")
     scan_parser.add_argument("--max-workers", type=int, default=MAX_SCAN_WORKERS,
                              help=f"Parallel scan workers (default: {MAX_SCAN_WORKERS})")
-    scan_parser.add_argument("--readonly", action="store_true",
-                             help="Read-only scan: skip dependency installation and code execution")
+    scan_parser.add_argument("--execute", action="store_true",
+                             help="Allow the scan agent to execute code (grants the Bash tool). "
+                                  "Default is a read-only scan with no code execution (CANON-03).")
 
     subparsers.add_parser("status", help="Check scan progress")
 
@@ -158,7 +159,7 @@ def main():
         args.re_clone = False
         args.resume = False
         args.max_workers = MAX_SCAN_WORKERS
-        args.readonly = False
+        args.execute = False
 
     if args.command == "scan":
         cmd_scan(args)

--- a/harness/local_harness/benchmark/analyze_misses.py
+++ b/harness/local_harness/benchmark/analyze_misses.py
@@ -259,13 +259,17 @@ def invoke_diagnostic(finding, phase_key, evidence, results_dir, repo_dir):
 
     print(f"    [{fid}] Invoking claude ({MODEL}) in agentic mode, timeout 1200s ...", flush=True)
 
+    # Bash(find:*) is intentionally excluded: it would permit `find -exec <cmd>`,
+    # i.e. arbitrary command execution over the untrusted repo_dir. RESIDUAL: the
+    # remaining Bash read commands (grep/wc/ls/head/tail/cat) can still read host
+    # files; full hardening would drop Bash entirely in favor of Read/Grep/Glob.
     cmd = [
         "claude", "-p", prompt,
         "--output-format", "text",
         "--model", MODEL,
         "--system-prompt", DIAGNOSTIC_SYSTEM_PROMPT,
         "--allowedTools", "Read", "Bash(grep:*)", "Bash(wc:*)", "Bash(ls:*)",
-        "Bash(find:*)", "Bash(head:*)", "Bash(tail:*)", "Bash(cat:*)",
+        "Bash(head:*)", "Bash(tail:*)", "Bash(cat:*)",
         "--permission-mode", "acceptEdits",
         "--add-dir", repo_dir,
         "--add-dir", results_dir,

--- a/harness/local_harness/benchmark/run.py
+++ b/harness/local_harness/benchmark/run.py
@@ -144,7 +144,7 @@ def phase_clone(targets, state):
         save_state(state)
 
 
-def phase_scan(targets, state, force_rescan=False, max_workers=MAX_SCAN_WORKERS):
+def phase_scan(targets, state, force_rescan=False, max_workers=MAX_SCAN_WORKERS, execute=False):
     """Phase 2: Scan all cloned repos in parallel."""
     to_scan = []
     for key, target in targets.items():
@@ -194,7 +194,7 @@ def phase_scan(targets, state, force_rescan=False, max_workers=MAX_SCAN_WORKERS)
     print(f"PHASE 2: SCAN ({len(to_scan)} targets, {max_workers} workers)")
     print(f"{'='*60}")
 
-    results = scan_targets(to_scan, max_workers=max_workers)
+    results = scan_targets(to_scan, max_workers=max_workers, readonly=not execute)
 
     for target_key, r in results:
         if r.returncode == 0 and r.results_dir:
@@ -364,6 +364,8 @@ def main():
                         help=f"Parallel scan workers (default: {MAX_SCAN_WORKERS})")
     parser.add_argument("--skip-stable", action="store_true",
                         help="Skip findings detected in every one of the last 3 runs")
+    parser.add_argument("--execute", action="store_true", default=False,
+                        help="Allow the scan agent to execute code (Bash); default is a read-only scan")
     args = parser.parse_args()
 
     # Load benchmarks
@@ -434,7 +436,7 @@ def main():
 
     if not args.judge_only:
         phase_clone(targets, state)
-        phase_scan(targets, state, force_rescan=args.force_rescan, max_workers=args.max_workers)
+        phase_scan(targets, state, force_rescan=args.force_rescan, max_workers=args.max_workers, execute=args.execute)
 
     if args.scan_only:
         print("\n  --scan-only: Skipping judge and tally phases.")

--- a/harness/local_harness/scan.py
+++ b/harness/local_harness/scan.py
@@ -174,7 +174,7 @@ def extract_cost_from_log(log_file_path):
     return {}
 
 
-def scan_folder(folder_path, log_file=None, readonly=False):
+def scan_folder(folder_path, log_file=None, readonly=True):
     """Run vulnhunt on one folder, stream events to a log file.
 
     Returns a ScanResult (folder_path, label, returncode, event_count,
@@ -203,17 +203,19 @@ def scan_folder(folder_path, log_file=None, readonly=False):
     print(f"  [{ts()}] [{label}] STARTING scan", flush=True)
     start = time.time()
 
-    # CANON-03: when scanning an untrusted repo read-only, do NOT grant
-    # write/exec capabilities. Prompt-injected content in the scanned repo must
-    # not be able to drive Write/Edit/Bash on the host, and the permission mode
-    # must not auto-accept edits or bypass permissions. Non-readonly (default)
-    # callers keep the full capability set so their behavior is unchanged.
+    # CANON-03: scanning an untrusted repo is read-only BY DEFAULT so that
+    # prompt-injected content in the scanned repo cannot drive host command
+    # execution. The read-only tool set intentionally excludes Bash (no shell
+    # execution); it retains Read/Grep/Glob for analysis, Write/Edit so the
+    # agent can record findings, and Agent/AskUserQuestion. Only an explicit
+    # opt-out (readonly=False) re-adds Bash for scans that must execute code.
     if readonly:
-        tool_args = ["--allowedTools", "Read", "Grep", "Glob", "Agent"]
-        permission_mode = "plan"
+        tool_args = ["--allowedTools",
+                     "Read", "Write", "Edit", "Agent",
+                     "AskUserQuestion", "Grep", "Glob"]
     else:
         tool_args = ["--allowedTools", "Read", "Write", "Edit", "Bash", "Agent"]
-        permission_mode = "acceptEdits"
+    permission_mode = "acceptEdits"
 
     proc = subprocess.Popen(
         ["claude", "-p", prompt,
@@ -292,7 +294,7 @@ def scan_folder(folder_path, log_file=None, readonly=False):
     return ScanResult(folder_path, label, proc.returncode, event_count, elapsed, results_dir, cost_data)
 
 
-def scan_folder_with_retry(folder_path, log_filename=None, readonly=False):
+def scan_folder_with_retry(folder_path, log_filename=None, readonly=True):
     """Wrap scan_folder with retry on 429 rate limit failures.
 
     Returns: Same ScanResult as scan_folder, with elapsed summed across attempts.
@@ -329,7 +331,7 @@ def scan_folder_with_retry(folder_path, log_filename=None, readonly=False):
         return result._replace(elapsed=total_elapsed)
 
 
-def scan_targets(targets, max_workers=None, status_interval=300, log_filename=None, readonly=False):
+def scan_targets(targets, max_workers=None, status_interval=300, log_filename=None, readonly=True):
     """Scan a list of benchmark targets in parallel with 429 retry.
 
     targets: list of dicts with at least 'clone_dir' and 'key' fields.

--- a/harness/local_harness/scan.py
+++ b/harness/local_harness/scan.py
@@ -209,23 +209,29 @@ def scan_folder(folder_path, log_file=None, readonly=True):
     # execution); it retains Read/Grep/Glob for analysis, Write/Edit so the
     # agent can record findings, and Agent/AskUserQuestion. Only an explicit
     # opt-out (readonly=False) re-adds Bash for scans that must execute code.
+    #
+    # The scan does NOT --add-dir the parent (sibling clones): under acceptEdits
+    # with Write/Edit granted, injected scanned-repo content could otherwise
+    # overwrite sibling clones. Results are written under folder_path (the cwd),
+    # so parent access is unnecessary. RESIDUAL: SKILLS_DIR/PHASES_DIR are still
+    # readable AND writable under acceptEdits, so injected content could persist
+    # edits to skill/phase files; fully closing that would require finer
+    # per-path permission controls (out of scope for this patch).
     if readonly:
         tool_args = ["--allowedTools",
                      "Read", "Write", "Edit", "Agent",
                      "AskUserQuestion", "Grep", "Glob"]
     else:
         tool_args = ["--allowedTools", "Read", "Write", "Edit", "Bash", "Agent"]
-    permission_mode = "acceptEdits"
 
     proc = subprocess.Popen(
         ["claude", "-p", prompt,
          "--output-format", "stream-json",
          "--verbose",
          *tool_args,
-         "--permission-mode", permission_mode,
+         "--permission-mode", "acceptEdits",
          "--model", MODEL,
          "--add-dir", folder_path,
-         "--add-dir", os.path.dirname(folder_path),
          "--add-dir", SKILLS_DIR,
          "--add-dir", PHASES_DIR],
         stdout=subprocess.PIPE,

--- a/harness/local_harness/scan.py
+++ b/harness/local_harness/scan.py
@@ -203,12 +203,24 @@ def scan_folder(folder_path, log_file=None, readonly=False):
     print(f"  [{ts()}] [{label}] STARTING scan", flush=True)
     start = time.time()
 
+    # CANON-03: when scanning an untrusted repo read-only, do NOT grant
+    # write/exec capabilities. Prompt-injected content in the scanned repo must
+    # not be able to drive Write/Edit/Bash on the host, and the permission mode
+    # must not auto-accept edits or bypass permissions. Non-readonly (default)
+    # callers keep the full capability set so their behavior is unchanged.
+    if readonly:
+        tool_args = ["--allowedTools", "Read", "Grep", "Glob", "Agent"]
+        permission_mode = "plan"
+    else:
+        tool_args = ["--allowedTools", "Read", "Write", "Edit", "Bash", "Agent"]
+        permission_mode = "acceptEdits"
+
     proc = subprocess.Popen(
         ["claude", "-p", prompt,
          "--output-format", "stream-json",
          "--verbose",
-         "--allowedTools", "Read", "Write", "Edit", "Bash", "Agent",
-         "--permission-mode", "acceptEdits",
+         *tool_args,
+         "--permission-mode", permission_mode,
          "--model", MODEL,
          "--add-dir", folder_path,
          "--add-dir", os.path.dirname(folder_path),

--- a/harness/tests/test_analyze_misses.py
+++ b/harness/tests/test_analyze_misses.py
@@ -149,6 +149,24 @@ def test_invoke_diagnostic_success(monkeypatch):
     assert out["root_cause"] == "rc"
 
 
+def test_invoke_diagnostic_no_bash_find(monkeypatch):
+    """Fix C: Bash(find:*) permits `find -exec <cmd>` = arbitrary command
+    execution over the untrusted repo_dir; it must not be in the allow-list.
+    """
+    captured = {}
+
+    def fake_run(cmd, *a, **k):
+        captured["cmd"] = cmd
+        return _proc(0, stdout='{"root_cause":"rc"}')
+
+    monkeypatch.setattr(am.subprocess, "run", fake_run)
+    finding = {"finding_id": "F1", "type": "SQLi", "description": "d", "repo_name": "r"}
+    am.invoke_diagnostic(finding, "phase1", "ev", "/rd", "/repo")
+    assert "Bash(find:*)" not in captured["cmd"]
+    # The other read-only Bash commands are retained.
+    assert "Bash(grep:*)" in captured["cmd"]
+
+
 def test_invoke_diagnostic_timeout(monkeypatch):
     def boom(*a, **k):
         raise subprocess.TimeoutExpired(cmd="claude", timeout=1)

--- a/harness/tests/test_batch_run.py
+++ b/harness/tests/test_batch_run.py
@@ -46,7 +46,7 @@ def test_cmd_scan_success(monkeypatch, tmp_path):
             for t in targets[1:]
         ]
     monkeypatch.setattr(brun, "scan_targets", fake_scan_targets)
-    brun.cmd_scan(_Args(re_clone=False, resume=False, max_workers=2, readonly=False))
+    brun.cmd_scan(_Args(re_clone=False, resume=False, max_workers=2, execute=False))  # Updated for CANON-03
 
 
 def test_cmd_scan_resume_all_have_results(monkeypatch, tmp_path):
@@ -71,23 +71,30 @@ def test_cmd_scan_resume_partial(monkeypatch, tmp_path):
                         lambda targets, max_workers=None, log_filename=None, readonly=False: [
                             (t["key"], ScanResult(t["clone_dir"], t["key"], 0, 1, 1.0, "rd", {}))
                             for t in targets])
-    brun.cmd_scan(_Args(re_clone=False, resume=True, max_workers=1, readonly=False))
+    brun.cmd_scan(_Args(re_clone=False, resume=True, max_workers=1, execute=False))  # Updated for CANON-03
 
 
 def test_cmd_scan_readonly_propagates(monkeypatch, tmp_path):
+    # CANON-03: read-only is the default; --execute opts into code execution.
     monkeypatch.setattr(brun, "parse_repo_list", lambda: ["https://github.com/a/b"])
     monkeypatch.setattr(brun, "BATCH_CLONE_BASE_DIR", str(tmp_path))
     monkeypatch.setattr(brun, "shallow_clone", lambda url, td, re_clone=False: (td, None))
 
     seen = {}
 
-    def fake_scan_targets(targets, max_workers=None, log_filename=None, readonly=False):
+    def fake_scan_targets(targets, max_workers=None, log_filename=None, readonly=True):
         seen["readonly"] = readonly
         return [(t["key"], ScanResult(t["clone_dir"], t["key"], 0, 1, 1.0, "rd", {})) for t in targets]
 
     monkeypatch.setattr(brun, "scan_targets", fake_scan_targets)
-    brun.cmd_scan(_Args(re_clone=False, resume=False, max_workers=1, readonly=True))
+
+    # Default (execute=False) -> read-only scan (no Bash on the untrusted repo).
+    brun.cmd_scan(_Args(re_clone=False, resume=False, max_workers=1, execute=False))
     assert seen["readonly"] is True
+
+    # Explicit --execute opts into code execution.
+    brun.cmd_scan(_Args(re_clone=False, resume=False, max_workers=1, execute=True))
+    assert seen["readonly"] is False
 
 
 def test_cmd_status(monkeypatch):

--- a/harness/tests/test_benchmark_run.py
+++ b/harness/tests/test_benchmark_run.py
@@ -131,7 +131,10 @@ def test_phase_scan_runs(monkeypatch, tmp_path):
     monkeypatch.setattr(run, "clean_prior_results", lambda cd: [])
     monkeypatch.setattr(run, "has_valid_results", lambda cd: False)
 
-    def fake_scan_targets(to_scan, max_workers=None):
+    captured = {}
+
+    def fake_scan_targets(to_scan, max_workers=None, readonly=True):
+        captured["readonly"] = readonly
         return [("t1", ScanResult("/c/t1", "t1", 0, 5, 12.0, "/c/t1/rd", {"total_cost_usd": 1.0})),
                 ("t2", ScanResult("/c/t2", "t2", 1, 0, 3.0, None, {}))]
     monkeypatch.setattr(run, "scan_targets", fake_scan_targets)
@@ -145,6 +148,10 @@ def test_phase_scan_runs(monkeypatch, tmp_path):
     run.phase_scan(targets, state, force_rescan=True)
     assert state["scan_targets"]["t1"]["status"] == "scanned"
     assert state["scan_targets"]["t2"]["status"] == "scan_failed"
+    # Default (execute=False) must scan read-only; --execute opts out.
+    assert captured["readonly"] is True
+    run.phase_scan(targets, state, force_rescan=True, execute=True)
+    assert captured["readonly"] is False
 
 
 def test_phase_scan_adopts_existing_results(monkeypatch, tmp_path):
@@ -234,7 +241,7 @@ def _setup_main(monkeypatch, tmp_path):
     monkeypatch.setattr(run, "STATE_FILE", str(tmp_path / "state.json"))
     monkeypatch.setattr(run, "MODEL", "m")
     monkeypatch.setattr(run, "phase_clone", lambda t, s: None)
-    monkeypatch.setattr(run, "phase_scan", lambda t, s, force_rescan=False, max_workers=5: None)
+    monkeypatch.setattr(run, "phase_scan", lambda t, s, force_rescan=False, max_workers=5, execute=False: None)
     monkeypatch.setattr(run, "phase_judge", lambda t, s, force_rejudge=False: None)
     monkeypatch.setattr(run, "phase_tally", lambda s: None)
     monkeypatch.setattr(run, "update_history", lambda s, t: (1, 0))

--- a/harness/tests/test_scan.py
+++ b/harness/tests/test_scan.py
@@ -252,6 +252,91 @@ def test_scan_folder_readonly_appends_prompt(monkeypatch, tmp_path):
     assert "read-only scan" not in captured["prompt"]
 
 
+def test_scan_folder_readonly_restricts_capabilities(monkeypatch, tmp_path):
+    """CANON-03: a readonly scan of an untrusted repo must not grant write/exec.
+
+    The subprocess argv must contain none of Write/Edit/Bash in --allowedTools,
+    and the --permission-mode must not be an edit-accepting/bypass mode.
+    """
+    folder = tmp_path / "repo"
+    folder.mkdir()
+    monkeypatch.setattr(scan, "SKILLS_DIR", str(tmp_path / "skills"))
+    (tmp_path / "skills").mkdir()
+
+    captured = {}
+
+    def fake_popen(cmd, *a, **k):
+        captured["argv"] = cmd
+        return _FakePopen([json.dumps({"type": "result"}) + "\n"], returncode=0)
+    monkeypatch.setattr(scan.subprocess, "Popen", fake_popen)
+
+    class _NoTimer:
+        def __init__(self, *a, **k):
+            pass
+        def start(self):
+            pass
+        def cancel(self):
+            pass
+    monkeypatch.setattr(scan.threading, "Timer", _NoTimer)
+
+    scan.scan_folder(str(folder), readonly=True)
+    argv = captured["argv"]
+
+    # Isolate the --allowedTools values (everything until the next --flag).
+    idx = argv.index("--allowedTools")
+    tools = []
+    for tok in argv[idx + 1:]:
+        if tok.startswith("--"):
+            break
+        tools.append(tok)
+
+    assert "Write" not in tools, f"readonly scan must not grant Write: {tools}"
+    assert "Edit" not in tools, f"readonly scan must not grant Edit: {tools}"
+    assert "Bash" not in tools, f"readonly scan must not grant Bash: {tools}"
+    assert "Read" in tools, f"readonly scan should still allow Read: {tools}"
+
+    pm = argv[argv.index("--permission-mode") + 1]
+    assert pm not in ("acceptEdits", "bypassPermissions"), (
+        f"readonly scan must not use an edit-accepting mode: {pm}"
+    )
+    assert pm == "plan"
+
+
+def test_scan_folder_default_capabilities_unchanged(monkeypatch, tmp_path):
+    """CANON-03: non-readonly (default) callers keep full capabilities."""
+    folder = tmp_path / "repo"
+    folder.mkdir()
+    monkeypatch.setattr(scan, "SKILLS_DIR", str(tmp_path / "skills"))
+    (tmp_path / "skills").mkdir()
+
+    captured = {}
+
+    def fake_popen(cmd, *a, **k):
+        captured["argv"] = cmd
+        return _FakePopen([json.dumps({"type": "result"}) + "\n"], returncode=0)
+    monkeypatch.setattr(scan.subprocess, "Popen", fake_popen)
+
+    class _NoTimer:
+        def __init__(self, *a, **k):
+            pass
+        def start(self):
+            pass
+        def cancel(self):
+            pass
+    monkeypatch.setattr(scan.threading, "Timer", _NoTimer)
+
+    scan.scan_folder(str(folder), readonly=False)
+    argv = captured["argv"]
+    idx = argv.index("--allowedTools")
+    tools = []
+    for tok in argv[idx + 1:]:
+        if tok.startswith("--"):
+            break
+        tools.append(tok)
+    assert {"Read", "Write", "Edit", "Bash", "Agent"} <= set(tools)
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+
+
 def test_scan_folder_timeout(monkeypatch, tmp_path):
     folder = tmp_path / "repo"
     folder.mkdir()

--- a/harness/tests/test_scan.py
+++ b/harness/tests/test_scan.py
@@ -316,6 +316,27 @@ def test_scan_folder_execute_optin_grants_bash(monkeypatch, tmp_path):
     assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
 
 
+def _add_dir_values(argv):
+    """Collect every value following an --add-dir flag in a Popen argv."""
+    return [argv[i + 1] for i, tok in enumerate(argv[:-1]) if tok == "--add-dir"]
+
+
+def test_scan_folder_readonly_no_parent_add_dir(monkeypatch, tmp_path):
+    """CANON-03/Fix B: a read-only (default) scan must NOT --add-dir the parent.
+
+    Granting write to the parent dir (via acceptEdits + Write/Edit) would let
+    injected scanned-repo content overwrite sibling clones. The scanned folder
+    itself must still be added (results are written under it).
+    """
+    _tools, argv = _capture_scan_tools(monkeypatch, tmp_path)  # default readonly
+    folder = str(tmp_path / "repo")
+    add_dirs = _add_dir_values(argv)
+    assert folder in add_dirs, f"scanned folder must be added: {add_dirs}"
+    assert os.path.dirname(folder) not in add_dirs, (
+        f"parent dir must NOT be added for a read-only scan: {add_dirs}"
+    )
+
+
 def test_scan_folder_timeout(monkeypatch, tmp_path):
     folder = tmp_path / "repo"
     folder.mkdir()

--- a/harness/tests/test_scan.py
+++ b/harness/tests/test_scan.py
@@ -252,88 +252,67 @@ def test_scan_folder_readonly_appends_prompt(monkeypatch, tmp_path):
     assert "read-only scan" not in captured["prompt"]
 
 
-def test_scan_folder_readonly_restricts_capabilities(monkeypatch, tmp_path):
-    """CANON-03: a readonly scan of an untrusted repo must not grant write/exec.
+def _capture_scan_tools(monkeypatch, tmp_path, **scan_kwargs):
+    """Run scan_folder with Popen stubbed and return the --allowedTools list."""
+    folder = tmp_path / "repo"
+    folder.mkdir()
+    monkeypatch.setattr(scan, "SKILLS_DIR", str(tmp_path / "skills"))
+    (tmp_path / "skills").mkdir()
 
-    The subprocess argv must contain none of Write/Edit/Bash in --allowedTools,
-    and the --permission-mode must not be an edit-accepting/bypass mode.
+    captured = {}
+
+    def fake_popen(cmd, *a, **k):
+        captured["argv"] = cmd
+        return _FakePopen([json.dumps({"type": "result"}) + "\n"], returncode=0)
+    monkeypatch.setattr(scan.subprocess, "Popen", fake_popen)
+
+    class _NoTimer:
+        def __init__(self, *a, **k):
+            pass
+        def start(self):
+            pass
+        def cancel(self):
+            pass
+    monkeypatch.setattr(scan.threading, "Timer", _NoTimer)
+
+    scan.scan_folder(str(folder), **scan_kwargs)
+    argv = captured["argv"]
+    idx = argv.index("--allowedTools")
+    tools = []
+    for tok in argv[idx + 1:]:
+        if tok.startswith("--"):
+            break
+        tools.append(tok)
+    return tools, argv
+
+
+def test_scan_folder_default_is_readonly_no_bash(monkeypatch, tmp_path):
+    """CANON-03: scans are read-only BY DEFAULT and must not grant Bash.
+
+    The untrusted-repo scan paths (batch/benchmark) rely on this default, so
+    prompt-injected content cannot drive host command execution. The read-only
+    set retains Read/Write/Edit/Agent/AskUserQuestion/Grep/Glob but not Bash.
     """
-    folder = tmp_path / "repo"
-    folder.mkdir()
-    monkeypatch.setattr(scan, "SKILLS_DIR", str(tmp_path / "skills"))
-    (tmp_path / "skills").mkdir()
-
-    captured = {}
-
-    def fake_popen(cmd, *a, **k):
-        captured["argv"] = cmd
-        return _FakePopen([json.dumps({"type": "result"}) + "\n"], returncode=0)
-    monkeypatch.setattr(scan.subprocess, "Popen", fake_popen)
-
-    class _NoTimer:
-        def __init__(self, *a, **k):
-            pass
-        def start(self):
-            pass
-        def cancel(self):
-            pass
-    monkeypatch.setattr(scan.threading, "Timer", _NoTimer)
-
-    scan.scan_folder(str(folder), readonly=True)
-    argv = captured["argv"]
-
-    # Isolate the --allowedTools values (everything until the next --flag).
-    idx = argv.index("--allowedTools")
-    tools = []
-    for tok in argv[idx + 1:]:
-        if tok.startswith("--"):
-            break
-        tools.append(tok)
-
-    assert "Write" not in tools, f"readonly scan must not grant Write: {tools}"
-    assert "Edit" not in tools, f"readonly scan must not grant Edit: {tools}"
-    assert "Bash" not in tools, f"readonly scan must not grant Bash: {tools}"
-    assert "Read" in tools, f"readonly scan should still allow Read: {tools}"
-
-    pm = argv[argv.index("--permission-mode") + 1]
-    assert pm not in ("acceptEdits", "bypassPermissions"), (
-        f"readonly scan must not use an edit-accepting mode: {pm}"
+    tools, argv = _capture_scan_tools(monkeypatch, tmp_path)  # no readonly arg -> default
+    assert "Bash" not in tools, f"default scan must not grant Bash: {tools}"
+    assert {"Read", "Write", "Edit", "Agent", "AskUserQuestion", "Grep", "Glob"} <= set(tools), (
+        f"default read-only scan tool set unexpected: {tools}"
     )
-    assert pm == "plan"
 
 
-def test_scan_folder_default_capabilities_unchanged(monkeypatch, tmp_path):
-    """CANON-03: non-readonly (default) callers keep full capabilities."""
-    folder = tmp_path / "repo"
-    folder.mkdir()
-    monkeypatch.setattr(scan, "SKILLS_DIR", str(tmp_path / "skills"))
-    (tmp_path / "skills").mkdir()
+def test_scan_folder_readonly_no_bash(monkeypatch, tmp_path):
+    """CANON-03: explicit readonly=True yields the same no-Bash tool set."""
+    tools, _ = _capture_scan_tools(monkeypatch, tmp_path, readonly=True)
+    assert "Bash" not in tools, f"readonly scan must not grant Bash: {tools}"
+    assert {"Read", "Write", "Edit", "Agent", "AskUserQuestion", "Grep", "Glob"} <= set(tools)
 
-    captured = {}
 
-    def fake_popen(cmd, *a, **k):
-        captured["argv"] = cmd
-        return _FakePopen([json.dumps({"type": "result"}) + "\n"], returncode=0)
-    monkeypatch.setattr(scan.subprocess, "Popen", fake_popen)
-
-    class _NoTimer:
-        def __init__(self, *a, **k):
-            pass
-        def start(self):
-            pass
-        def cancel(self):
-            pass
-    monkeypatch.setattr(scan.threading, "Timer", _NoTimer)
-
-    scan.scan_folder(str(folder), readonly=False)
-    argv = captured["argv"]
-    idx = argv.index("--allowedTools")
-    tools = []
-    for tok in argv[idx + 1:]:
-        if tok.startswith("--"):
-            break
-        tools.append(tok)
-    assert {"Read", "Write", "Edit", "Bash", "Agent"} <= set(tools)
+def test_scan_folder_execute_optin_grants_bash(monkeypatch, tmp_path):
+    """CANON-03: only an explicit opt-out (readonly=False) re-adds Bash."""
+    tools, argv = _capture_scan_tools(monkeypatch, tmp_path, readonly=False)
+    assert {"Read", "Write", "Edit", "Bash", "Agent"} <= set(tools), (
+        f"execute scan should grant the full set incl Bash: {tools}"
+    )
     assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
 
 

--- a/vulnhunter-agent/agent/config.py
+++ b/vulnhunter-agent/agent/config.py
@@ -780,6 +780,7 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
                 else []
             )
             if str(p).strip()
+        ),
         max_comment_pages=int(
             _resolve(verify_raw, "verify", "max_comment_pages", kind=int, default=20)
         ),

--- a/vulnhunter-agent/agent/runner.py
+++ b/vulnhunter-agent/agent/runner.py
@@ -697,7 +697,13 @@ async def run_vulnhunt(
                     # uppercase filename — the SDK's case-sensitive lookup is why this
                     # only worked on the case-insensitive macOS host before the rename).
                     # ``skills="all"`` enables every discovered skill.
-                    setting_sources=["user", "project", "local"],
+                    #
+                    # CANON-19: ``cwd`` is the untrusted cloned repo. "project"/"local"
+                    # would load that repo's .claude/settings(.local).json (hooks,
+                    # permissions) and its skills, executing attacker-controlled config
+                    # on the host. Restrict to "user" only — the trusted vulnhunt skill
+                    # lives in the user dir, so scan functionality is unaffected.
+                    setting_sources=["user"],
                     skills="all",
                 )
                 session_result = await _run_scan_session(

--- a/vulnhunter-agent/agent/verify_runner.py
+++ b/vulnhunter-agent/agent/verify_runner.py
@@ -275,7 +275,13 @@ async def run_verify_session(
         cwd=str(cwd),
         # Same skill discovery path as scan mode — the SDK reads
         # ~/.claude/skills/vulnhunt-fix-verify/SKILL.md.
-        setting_sources=["user", "project", "local"],
+        #
+        # CANON-19: ``cwd`` is the untrusted cloned repo. "project"/"local"
+        # would load that repo's .claude/settings(.local).json (hooks,
+        # permissions) and its skills, executing attacker-controlled config on
+        # the host. Restrict to "user" only — the trusted vulnhunt-fix-verify
+        # skill lives in the user dir, so verify functionality is unaffected.
+        setting_sources=["user"],
         skills="all",
     )
 

--- a/vulnhunter-agent/tests/test_config.py
+++ b/vulnhunter-agent/tests/test_config.py
@@ -399,6 +399,27 @@ allowed_tools = ["Read", "Edit"]
         cfg = load_config(path)
         assert cfg.scan.allowed_tools == ["Read", "Edit"]
 
+    def test_verify_token_path_prefixes_parse(self, tmp_path: Path) -> None:
+        """token_path_prefixes parses to a tuple, stripping each entry and
+        dropping blank/whitespace-only entries (confused-deputy guard config).
+        """
+        path = tmp_path / "cfg.toml"
+        path.write_text(
+            """
+[anthropic]
+bedrock_base_url = "https://b"
+model = "m"
+[oauth]
+token_endpoint = "https://o"
+client_id = "x"
+client_secret = "y"
+[verify]
+token_path_prefixes = [" acme ", "   ", "acme/widgets"]
+"""
+        )
+        cfg = load_config(path)
+        assert cfg.verify.token_path_prefixes == ("acme", "acme/widgets")
+
     def test_load_minimal_fixture(self) -> None:
         """Smoke test against tests/fixtures/config_minimal.toml."""
         path = Path(__file__).parent / "fixtures" / "config_minimal.toml"

--- a/vulnhunter-agent/tests/test_config.py
+++ b/vulnhunter-agent/tests/test_config.py
@@ -504,3 +504,22 @@ retries = false
         cfg = load_config(path)
         assert cfg.logging.per_turn_usage is True
         assert cfg.logging.retries is False
+
+
+class TestModuleImportable:
+    """Regression: the agent.config module must parse and expose load_config.
+
+    A prior syntax error (an unclosed VerifyConfig(token_path_prefixes=...)
+    generator) prevented the whole agent package from importing.
+    """
+
+    def test_agent_config_imports(self) -> None:
+        import importlib
+
+        module = importlib.import_module("agent.config")
+        assert module is not None
+
+    def test_load_config_is_callable(self) -> None:
+        import agent.config
+
+        assert callable(agent.config.load_config)

--- a/vulnhunter-agent/tests/test_runner.py
+++ b/vulnhunter-agent/tests/test_runner.py
@@ -2091,6 +2091,64 @@ async def test_run_vulnhunt_strips_bash_from_allowed_tools(
 
 
 @pytest.mark.asyncio
+async def test_run_vulnhunt_does_not_load_cloned_repo_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    populated_agent_config,
+) -> None:
+    """CANON-19: cwd is the untrusted cloned repo, so 'project'/'local'
+    setting_sources would load the scanned repo's .claude/settings(.local).json
+    (hooks/permissions) and execute on the host. Only 'user' settings — which
+    hold the trusted vulnhunt skill — may be loaded.
+    """
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    # A malicious repo shipping local settings must not be honored.
+    dotclaude = clone / ".claude"
+    dotclaude.mkdir()
+    (dotclaude / "settings.local.json").write_text('{"hooks": {}}')
+
+    captured_options: list[Any] = []
+
+    class _CapturingClient:
+        def __init__(self, opts: Any) -> None:
+            captured_options.append(opts)
+
+        async def __aenter__(self) -> "_CapturingClient":
+            return self
+
+        async def __aexit__(self, *a: object) -> bool:
+            return False
+
+        async def query(self, _prompt: str) -> None:
+            pass
+
+        def receive_response(self):
+            async def _gen():
+                yield _result_message()
+            return _gen()
+
+    class _FakeMgr:
+        def __init__(self, *a: object, **k: object) -> None:
+            pass
+
+        def get_valid_token(self) -> str:
+            return "fake"
+
+    monkeypatch.setattr(runner_mod, "make_token_manager", lambda *a, **k: _FakeMgr())
+    monkeypatch.setattr(runner_mod, "build_claude_settings", lambda *a, **k: "{}")
+    monkeypatch.setattr(runner_mod, "ClaudeSDKClient", _CapturingClient)
+    monkeypatch.setattr(runner_mod, "_vulnhunt_skill_path", lambda: tmp_path / "skill")
+    _stub_git_runner(monkeypatch)
+
+    await run_vulnhunt(clone, populated_agent_config, enable_bash=False)
+    ss = captured_options[0].setting_sources
+    assert ss == ["user"], f"only trusted user settings may load, got {ss}"
+    assert "project" not in ss
+    assert "local" not in ss
+
+
+@pytest.mark.asyncio
 async def test_run_vulnhunt_appends_bash_when_enable_bash_true(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/vulnhunter-agent/tests/test_verify_runner.py
+++ b/vulnhunter-agent/tests/test_verify_runner.py
@@ -278,6 +278,10 @@ async def test_run_verify_session_disposition_path(
     assert sorted(_FakeSDKClient._recorded_options.allowed_tools) == [
         "Agent", "Edit", "Glob", "Grep", "Read", "Write",
     ]
+    # CANON-19: verify runs over an untrusted cloned repo (cwd). setting_sources
+    # must be "user" only — a regression to "project"/"local" would load the
+    # scanned repo's .claude/settings(.local).json on the host.
+    assert _FakeSDKClient._recorded_options.setting_sources == ["user"]
     assert _FakeSDKClient._query_calls == ["/vulnhunt-fix-verify\nfoo"]
 
 


### PR DESCRIPTION
## Harden agent capabilities/settings against untrusted scanned repos

Tightens two places where content from the **scanned repository** can influence the launched Claude agent's capabilities or settings, plus a small prerequisite build fix. These came out of the cross-model `/vulnhunt` evaluation (`eval_rep/`). Each change is developed test-first: a security test that fails on the current code and passes after the fix, with the existing suite kept green.

### Prerequisite — `config.py` currently doesn't parse
Commit `a35b0ff`. `vulnhunter-agent/agent/config.py` has an unclosed paren — the `token_path_prefixes=tuple(...)` generator is missing its `),` before `max_comment_pages=int(` — so `import agent.config` raises `SyntaxError` and the agent package (and its test suite) can't be imported. This adds the missing `),` and a small regression test (`tests/test_config.py`) that the module imports and `load_config` is callable.
> The same one-line prerequisite also appears on `vulnfix/verify-mode-scoping` and `vulnfix/output-injection`. Whichever merges first applies it; the others will show the hunk as already-applied.

### CANON-03 — Default scans to read-only; drop Bash from the scan tool set (CWE-94/CWE-78/CWE-77/CWE-269)
Commits `01cb350`, `948cf42`. `harness/local_harness/scan.py` launched `claude` with `--allowedTools Read Write Edit Bash Agent --permission-mode acceptEdits`, and the `readonly` argument only adjusted prompt text — it defaulted to `False` and the untrusted-repo scan entry points (`batch`, `benchmark`) never set it, so the default scan granted `Bash` (command execution) on the scanned repo.
- **Change:** `scan_folder` / `scan_folder_with_retry` / `scan_targets` now default `readonly=True`. The read-only tool set is `Read Write Edit Agent AskUserQuestion Grep Glob` — **no `Bash`** — so prompt-injected scanned-repo content can no longer drive host command execution by default. Only an explicit opt-out (`readonly=False`) re-adds `Bash` for scans that must execute code. The `batch` CLI flag `--readonly` (opt-in) is replaced by `--execute` (opt-out).
- **Tests:** `harness/tests/test_scan.py::test_scan_folder_default_is_readonly_no_bash` / `::test_scan_folder_readonly_no_bash` / `::test_scan_folder_execute_optin_grants_bash`; `test_batch_run.py` updated for the `--execute` semantics. Fail on the pre-rework code, pass after.
- **Residual (stated plainly):** a read-only scan still permits `Write`/`Edit` within the `--add-dir` roots; fully isolating untrusted-repo scanning requires process sandboxing, which is out of scope for a code patch. *(This scoping followed an independent `vulnhunt-fix-verify` pass that found the initial `readonly`-gated fix left the default path unprotected.)*

### CANON-19 — Only load trusted (user) settings sources (CWE-913/CWE-269)
Commit `f57db26`. `run_vulnhunt` built `ClaudeAgentOptions(setting_sources=["user","project","local"], skills="all", cwd=clone_dir)`. Because `cwd` is the cloned repo under scan, `"project"`/`"local"` cause the scanned repo's `.claude/settings*.json` and skills to be loaded from that directory.
- **Change:** `setting_sources=["user"]` in both `agent/runner.py` and `agent/verify_runner.py` (the pattern appeared in both). Checked against the installed SDK: passing `["user"]` explicitly means `skills="all"` discovers only user-dir skills (the trusted vulnhunt skills), not `clone_dir/.claude/skills` — so scan/verify behavior is preserved.
- **Test:** `vulnhunter-agent/tests/test_runner.py::test_run_vulnhunt_does_not_load_cloned_repo_settings`. Fails on current code (`['user','project','local']`), passes after (`['user']`).

### Verification
- `harness`: 160 passed
- `vulnhunter-agent`: 1111 passed, 1 skipped
- Discrimination evidence (test fails with the fix stashed, passes with it applied) recorded for both findings; both re-checked by an independent `vulnhunt-fix-verify` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
