### PR TITLE
Add Windows install/uninstall scripts and venv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ work/
 .vulnhunter-fix/
 .installed-from
 
+# pip download cache (created by install.cmd)
+pip/
+
 # Stray dir from a mis-quoted URL (e.g. a test writing "https://..." as a path)
 https:/
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,6 @@ work/
 .vulnhunter-fix/
 .installed-from
 
-# pip download cache (created by install.cmd)
-pip/
-
 # Stray dir from a mis-quoted URL (e.g. a test writing "https://..." as a path)
 https:/
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,21 @@ cd vulnhunter
 # ./uninstall.sh    
 ```
 
+On Windows, use the `.cmd` equivalents from a `cmd.exe` or PowerShell prompt:
+
+```bat
+git clone https://github.com/capitalone/vulnhunter.git
+cd vulnhunter
+
+REM Copy skills into %USERPROFILE%\.claude\skills\
+install.cmd
+
+REM (Optional) To clean up or remove installed skills
+REM uninstall.cmd
+```
+
 > [!NOTE]
-> `install.sh` copies files directly (rather than symlinking) because symlinks can break `find`/`glob` functionality inside subagents. Re-run `./install.sh` after pulling updates to refresh your local environment.
+> `install.sh`/`install.cmd` copy files directly (rather than symlinking) because symlinks can break `find`/`glob` functionality inside subagents. Re-run the install script after pulling updates to refresh your local environment.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ git clone https://github.com/capitalone/vulnhunter.git
 cd vulnhunter
 
 REM Copy skills into %USERPROFILE%\.claude\skills\
-install.cmd
+.\install.cmd
 
 REM (Optional) To clean up or remove installed skills
-REM uninstall.cmd
+REM .\uninstall.cmd
 ```
 
 > [!NOTE]

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,156 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+rem USERPROFILE guard: destinations (and the rmdir below) derive from
+rem USERPROFILE. An unset USERPROFILE would turn deletes into operations on
+rem a bad root path -- refuse cleanly.
+if "%USERPROFILE%"=="" (
+    echo error: USERPROFILE unset -- refusing to run install.cmd 1>&2
+    exit /b 1
+)
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+set "SKILLS_PARENT=%USERPROFILE%\.claude\skills"
+
+if not exist "%SKILLS_PARENT%" (
+    echo Creating directory %SKILLS_PARENT%
+    mkdir "%SKILLS_PARENT%"
+)
+
+set "PYEXE="
+call :find_python
+if "%PYEXE%"=="" (
+    echo error: python 3.11+ not found ^(needed for vulnhunter-fix's bundled venv^). 1>&2
+    echo install Python 3.11+ from https://www.python.org/downloads/ and re-run install.cmd. 1>&2
+    exit /b 1
+)
+
+set "installed_any=0"
+for %%S in (vulnhunt vulnhunt-fix-verify vulnhunter-fix) do (
+    call :install_one "%%S"
+    if errorlevel 1 exit /b 1
+)
+
+echo.
+if "%installed_any%"=="1" (
+    echo To update after pulling changes: re-run install.cmd
+    echo To uninstall: "%SCRIPT_DIR%\uninstall.cmd"
+) else (
+    echo No skills were installed.
+)
+
+endlocal
+exit /b 0
+
+:install_one
+setlocal
+set "name=%~1"
+set "src=%SCRIPT_DIR%\%name%"
+set "dst=%SKILLS_PARENT%\%name%"
+
+if not exist "%src%\SKILL.md" (
+    if "%name%"=="vulnhunt" (
+        echo Error: SKILL.md not found at %src% 1>&2
+        echo Make sure you are running this script from the repository root. 1>&2
+        endlocal & exit /b 1
+    ) else (
+        echo Skipping %name% -- %src%\SKILL.md not present on this branch.
+        endlocal & exit /b 0
+    )
+)
+
+rem Handle an existing destination (junction/symlink or plain directory).
+if exist "%dst%\" (
+    echo Removing old copy of %name%...
+    rmdir /s /q "%dst%"
+)
+
+rem Copy files (not a symlink/junction -- links break find/glob in subagents).
+robocopy "%src%" "%dst%" /E /NFL /NDL /NJH /NJS >nul
+if errorlevel 8 (
+    echo error: failed to copy %src% to %dst% 1>&2
+    endlocal & exit /b 1
+)
+
+rem Record the source commit so a skill's staleness check (e.g.
+rem vulnhunter-fix SKILL.md Step 0b) can compare the installed copy against
+rem upstream main. Best-effort: skipped outside a git checkout.
+git -C "%SCRIPT_DIR%" rev-parse HEAD > "%dst%\.installed-from" 2>nul
+echo Installed %name% (copied to %dst%)
+
+rem vulnhunter-fix ships a Python package whose runtime deps (jsonschema,
+rem graphifyy) must live in a bundled venv that scripts\_skill_bootstrap.py
+rem loads. The other skills are prompt-only and need no venv.
+if "%name%"=="vulnhunter-fix" (
+    call :build_vulnfix_venv "%dst%"
+    if errorlevel 1 (
+        endlocal & exit /b 1
+    )
+)
+
+endlocal & set "installed_any=1" & exit /b 0
+
+:build_vulnfix_venv
+setlocal
+set "skill_dir=%~1"
+set "venv=%skill_dir%\.venv"
+
+if exist "%venv%\" (
+    rmdir /s /q "%venv%"
+)
+echo   creating bundled venv with %PYEXE%
+rem Note: interpreter/launcher failures can exit with large negative codes,
+rem which "if errorlevel N" misreads as success. Check !ERRORLEVEL! for
+rem exact equality to 0 instead.
+call %PYEXE% -m venv "%venv%"
+if not !ERRORLEVEL!==0 (
+    echo error: failed to create venv at %venv% 1>&2
+    endlocal & exit /b 1
+)
+
+"%venv%\Scripts\python.exe" -m pip install --quiet --disable-pip-version-check --upgrade pip
+echo   installing runtime deps into venv: jsonschema^>=4.18 graphifyy^>=0.8.14,^<0.9.0
+"%venv%\Scripts\python.exe" -m pip install --quiet --disable-pip-version-check "jsonschema>=4.18" "graphifyy>=0.8.14,<0.9.0"
+if not !ERRORLEVEL!==0 (
+    echo error: failed to install bundled deps into %venv% 1>&2
+    endlocal & exit /b 1
+)
+
+rem Smoke test: the bootstrap must resolve both deps.
+call %PYEXE% -c "import sys; sys.path.insert(0, r'%skill_dir%\scripts'); import _skill_bootstrap; import jsonschema, graphify" >nul 2>&1
+if not !ERRORLEVEL!==0 (
+    echo error: bootstrap smoke test failed -- venv built but jsonschema/graphify not importable. 1>&2
+    echo        check %venv%\Lib\site-packages\ 1>&2
+    endlocal & exit /b 1
+)
+echo   bundled venv ready: %venv%
+endlocal & exit /b 0
+
+:find_python
+rem Prefer the py launcher pinned to 3.11 (graphifyy ships per-minor wheels
+rem and 3.11 is the reference minor); otherwise accept any interpreter that
+rem satisfies pyproject's requires-python (>=3.11).
+rem Note: some launcher/interpreter failures exit with large negative codes
+rem (e.g. "py -3.11" when 3.11 isn't installed), which "if errorlevel N"
+rem misreads as success since it compares signed integers against N. Check
+rem !ERRORLEVEL! for exact equality to 0 instead.
+where py >nul 2>nul
+if !ERRORLEVEL!==0 (
+    py -3.11 -c "import sys" >nul 2>nul
+    if !ERRORLEVEL!==0 (
+        set "PYEXE=py -3.11"
+        exit /b 0
+    )
+)
+for %%C in (python3.13 python3.12 python3.11 python) do (
+    where %%C >nul 2>nul
+    if !ERRORLEVEL!==0 (
+        %%C -c "import sys; sys.exit(0 if sys.version_info[:2] >= (3,11) else 1)" >nul 2>nul
+        if !ERRORLEVEL!==0 (
+            set "PYEXE=%%C"
+            exit /b 0
+        )
+    )
+)
+exit /b 0

--- a/install.cmd
+++ b/install.cmd
@@ -18,14 +18,6 @@ if not exist "%SKILLS_PARENT%" (
     mkdir "%SKILLS_PARENT%"
 )
 
-set "PYEXE="
-call :find_python
-if "%PYEXE%"=="" (
-    echo error: python 3.11+ not found ^(needed for vulnhunter-fix's bundled venv^). 1>&2
-    echo install Python 3.11+ from https://www.python.org/downloads/ and re-run install.cmd. 1>&2
-    exit /b 1
-)
-
 set "installed_any=0"
 for %%S in (vulnhunt vulnhunt-fix-verify vulnhunter-fix) do (
     call :install_one "%%S"
@@ -92,9 +84,17 @@ if "%name%"=="vulnhunter-fix" (
 endlocal & set "installed_any=1" & exit /b 0
 
 :build_vulnfix_venv
-setlocal
+setlocal EnableDelayedExpansion
 set "skill_dir=%~1"
 set "venv=%skill_dir%\.venv"
+
+set "PYEXE="
+call :find_python
+if "%PYEXE%"=="" (
+    echo error: python 3.11+ not found ^(needed for vulnhunter-fix's bundled venv^). 1>&2
+    echo install Python 3.11+ from https://www.python.org/downloads/ and re-run install.cmd. 1>&2
+    endlocal & exit /b 1
+)
 
 if exist "%venv%\" (
     rmdir /s /q "%venv%"
@@ -109,16 +109,26 @@ if not !ERRORLEVEL!==0 (
     endlocal & exit /b 1
 )
 
+rem Pin must stay in sync with install.sh's VULNFIX_DEPS and
+rem preflight.py's REQ-GRA-001.
+set VULNFIX_DEPS="jsonschema>=4.18" "graphifyy>=0.8.14,<0.9.0"
+
 "%venv%\Scripts\python.exe" -m pip install --quiet --disable-pip-version-check --upgrade pip
-echo   installing runtime deps into venv: jsonschema^>=4.18 graphifyy^>=0.8.14,^<0.9.0
-"%venv%\Scripts\python.exe" -m pip install --quiet --disable-pip-version-check "jsonschema>=4.18" "graphifyy>=0.8.14,<0.9.0"
+if not !ERRORLEVEL!==0 (
+    echo error: failed to upgrade pip in %venv% 1>&2
+    endlocal & exit /b 1
+)
+echo   installing runtime deps into venv: %VULNFIX_DEPS%
+"%venv%\Scripts\python.exe" -m pip install --quiet --disable-pip-version-check %VULNFIX_DEPS%
 if not !ERRORLEVEL!==0 (
     echo error: failed to install bundled deps into %venv% 1>&2
     endlocal & exit /b 1
 )
 
-rem Smoke test: the bootstrap must resolve both deps.
-call %PYEXE% -c "import sys; sys.path.insert(0, r'%skill_dir%\scripts'); import _skill_bootstrap; import jsonschema, graphify" >nul 2>&1
+rem Smoke test: run the venv's own interpreter directly (not %PYEXE%) so
+rem this tests the venv contents without depending on _skill_bootstrap's
+rem re-exec mechanism.
+"%venv%\Scripts\python.exe" -c "import jsonschema, graphify" >nul 2>&1
 if not !ERRORLEVEL!==0 (
     echo error: bootstrap smoke test failed -- venv built but jsonschema/graphify not importable. 1>&2
     echo        check %venv%\Lib\site-packages\ 1>&2

--- a/uninstall.cmd
+++ b/uninstall.cmd
@@ -1,0 +1,36 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+rem USERPROFILE guard: dst (and its rmdir /s /q) derive from USERPROFILE. An
+rem unset USERPROFILE would turn deletes into operations on a bad root path
+rem -- refuse cleanly. The recursive remove already takes the bundled .venv
+rem with it.
+if "%USERPROFILE%"=="" (
+    echo error: USERPROFILE unset -- refusing to run uninstall.cmd 1>&2
+    exit /b 1
+)
+
+set "SKILLS_PARENT=%USERPROFILE%\.claude\skills"
+
+rem Skill names to remove (must match the names install.cmd writes).
+set "removed_any=0"
+for %%S in (vulnhunt vulnhunt-fix-verify vulnhunter-fix) do (
+    set "dst=%SKILLS_PARENT%\%%S"
+    if exist "!dst!\" (
+        rmdir /s /q "!dst!"
+        echo Removed !dst!
+        set "removed_any=1"
+    ) else (
+        echo %%S is not installed ^(no entry at !dst!^)
+    )
+)
+
+echo.
+if "%removed_any%"=="1" (
+    echo Uninstalled VulnHunter skills.
+) else (
+    echo Nothing to uninstall.
+)
+
+endlocal
+exit /b 0

--- a/vulnhunter-fix/scripts/_skill_bootstrap.py
+++ b/vulnhunter-fix/scripts/_skill_bootstrap.py
@@ -18,9 +18,13 @@ script under the bundled venv's Python if it detects a mismatch. In
 dev flow (no bundled venv present) it's a no-op.
 
 Side effects:
-- ``os.execv`` replaces the process — anything imported before this
-  module is discarded. Callers must import this FIRST, before any of
-  the deps that trigger the mismatch.
+- On POSIX, ``os.execv`` replaces the process — anything imported before
+  this module is discarded. Callers must import this FIRST, before any
+  of the deps that trigger the mismatch. On Windows, ``os.execv`` does
+  not block (it goes through the CRT's ``_wexecv``/``_wspawnv`` and
+  returns control to the caller with the parent's exit status while the
+  child runs detached), so a blocking ``subprocess.run`` is used there
+  instead and the current process exits with the child's real code.
 - Only fires when a Python binary exists inside the bundled venv
   (``.venv/bin/python3`` on POSIX, ``.venv/Scripts/python.exe`` on Windows).
 """
@@ -43,7 +47,7 @@ _VENV_PY = (
 def _same_interpreter(a: str, b: str) -> bool:
     """Robustly compare two Python executables through symlinks."""
     try:
-        return os.path.realpath(a) == os.path.realpath(b)
+        return os.path.normcase(os.path.realpath(a)) == os.path.normcase(os.path.realpath(b))
     except OSError:
         return False
 
@@ -55,11 +59,23 @@ if (
     os.path.isfile(_VENV_PY)
     and not _same_interpreter(sys.executable, _VENV_PY)
     and os.environ.get("VULNFIX_SKILL_REEXEC") != "1"
+    and sys.argv[0] != "-c"
 ):
     # Pass the flag so the child process doesn't loop if realpath comparison
     # somehow disagrees between runs (e.g., filesystem-level symlink quirks).
     os.environ["VULNFIX_SKILL_REEXEC"] = "1"
-    os.execv(_VENV_PY, [_VENV_PY, *sys.argv])
+    if os.name == "nt":
+        # os.execv doesn't block on Windows: CPython routes it through the
+        # CRT's _wexecv, which _wspawnv(_P_OVERLAY, ...)s the child and
+        # returns control to the caller immediately with the *parent's*
+        # exit status, while the child keeps running detached. Callers that
+        # rely on this script's exit code (gates, smoke tests) would read a
+        # false success. Use a blocking subprocess instead.
+        import subprocess
+
+        sys.exit(subprocess.run([_VENV_PY, *sys.argv]).returncode)
+    else:
+        os.execv(_VENV_PY, [_VENV_PY, *sys.argv])
 
 
 def _prepend_once(path: str) -> None:

--- a/vulnhunter-fix/scripts/_skill_bootstrap.py
+++ b/vulnhunter-fix/scripts/_skill_bootstrap.py
@@ -21,7 +21,8 @@ Side effects:
 - ``os.execv`` replaces the process — anything imported before this
   module is discarded. Callers must import this FIRST, before any of
   the deps that trigger the mismatch.
-- Only fires when a ``python3`` binary exists inside ``.venv/bin/``.
+- Only fires when a Python binary exists inside the bundled venv
+  (``.venv/bin/python3`` on POSIX, ``.venv/Scripts/python.exe`` on Windows).
 """
 from __future__ import annotations
 
@@ -32,7 +33,11 @@ import sys
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _SKILL_ROOT = os.path.dirname(_HERE)
-_VENV_PY = os.path.join(_SKILL_ROOT, ".venv", "bin", "python3")
+_VENV_PY = (
+    os.path.join(_SKILL_ROOT, ".venv", "Scripts", "python.exe")
+    if os.name == "nt"
+    else os.path.join(_SKILL_ROOT, ".venv", "bin", "python3")
+)
 
 
 def _same_interpreter(a: str, b: str) -> bool:
@@ -64,12 +69,16 @@ def _prepend_once(path: str) -> None:
 
 # 2. Under the bundled Python OR in dev flow: put the matching-minor's
 #    site-packages at index 0 (defensive; usually already present).
-_matching = os.path.join(
-    _SKILL_ROOT,
-    ".venv",
-    "lib",
-    f"python{sys.version_info.major}.{sys.version_info.minor}",
-    "site-packages",
+_matching = (
+    os.path.join(_SKILL_ROOT, ".venv", "Lib", "site-packages")
+    if os.name == "nt"
+    else os.path.join(
+        _SKILL_ROOT,
+        ".venv",
+        "lib",
+        f"python{sys.version_info.major}.{sys.version_info.minor}",
+        "site-packages",
+    )
 )
 _prepend_once(_matching)
 

--- a/vulnhunter-fix/scripts/preflight.py
+++ b/vulnhunter-fix/scripts/preflight.py
@@ -110,9 +110,32 @@ def check_claude_cli():
         check("Claude CLI", False, "cannot determine version")
 
 
+def _free_disk_bytes(path: str) -> int:
+    """Free disk space in bytes for the volume containing ``path``.
+
+    os.statvfs doesn't exist on Windows — the CRT has no statvfs() for
+    CPython to wrap — so this queries GetDiskFreeSpaceExW via ctypes there
+    instead.
+    """
+    if os.name == "nt":
+        import ctypes
+
+        free_bytes = ctypes.c_ulonglong(0)
+        if not ctypes.windll.kernel32.GetDiskFreeSpaceExW(
+            ctypes.c_wchar_p(os.path.abspath(path)), None, None, ctypes.byref(free_bytes)
+        ):
+            raise OSError("GetDiskFreeSpaceExW failed")
+        return free_bytes.value
+    stat = os.statvfs(path)
+    return stat.f_bavail * stat.f_frsize
+
+
 def check_disk_space():
-    stat = os.statvfs(".")
-    free_gb = (stat.f_bavail * stat.f_frsize) / (1024 ** 3)
+    try:
+        free_gb = _free_disk_bytes(".") / (1024 ** 3)
+    except (OSError, AttributeError):
+        check("Disk space", True, "cannot determine — skipping check")
+        return
     passed = free_gb >= 5.0
     check(
         f"Disk space ({free_gb:.1f} GB free)",
@@ -121,14 +144,42 @@ def check_disk_space():
     )
 
 
+def _total_memory_bytes() -> int:
+    """Total physical RAM in bytes. os.sysconf doesn't exist on Windows —
+    the CRT has no sysconf() for CPython to wrap — so this queries
+    GlobalMemoryStatusEx via ctypes there instead.
+    """
+    if os.name == "nt":
+        import ctypes
+
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+        if not ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            raise OSError("GlobalMemoryStatusEx failed")
+        return stat.ullTotalPhys
+    return os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+
+
 def check_memory():
     try:
-        mem_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
-        mem_gb = mem_bytes / (1024 ** 3)
+        mem_gb = _total_memory_bytes() / (1024 ** 3)
         cpus = os.cpu_count() or 1
         slots = max(1, min(cpus, int(mem_gb // 4), 8))
         check(f"Memory ({mem_gb:.1f} GB, {cpus} CPUs → {slots} parallel slots)", True)
-    except (ValueError, OSError):
+    except (ValueError, OSError, AttributeError):
         check("Memory", True, "cannot determine — will default to conservative settings")
 
 
@@ -379,8 +430,17 @@ def _print_bootstrap_hint():
         return  # Deps ARE importable — some other check is failing; no hint needed.
 
     skill_dir = os.path.expanduser("~/.claude/skills/vulnhunter-fix")
-    install_sh = os.path.join(skill_dir, "install.sh")
-    venv_python = os.path.join(skill_dir, ".venv", "bin", "python3")
+    skill_installed = os.path.isfile(os.path.join(skill_dir, "SKILL.md"))
+    # install.sh/install.cmd live at the repo root and are never copied into
+    # the installed skill dir by either installer, so the remediation hint
+    # can only ever point back at the user's source checkout, not a path
+    # under skill_dir — there is nothing there to run.
+    if os.name == "nt":
+        venv_python = os.path.join(skill_dir, ".venv", "Scripts", "python.exe")
+        run_install_hint = "    install.cmd"
+    else:
+        venv_python = os.path.join(skill_dir, ".venv", "bin", "python3")
+        run_install_hint = "    bash install.sh"
 
     print("\nBootstrap hint:")
     if os.path.isfile(venv_python):
@@ -392,20 +452,22 @@ def _print_bootstrap_hint():
         print("  installed skill's scripts import _skill_bootstrap (they do")
         print("  by default) and re-run preflight — the re-exec will")
         print("  transparently switch to the bundled Python 3.11.")
-        print("  If that still fails, rebuild the venv:")
-        print(f"    bash {install_sh}")
-    elif os.path.isfile(install_sh):
-        # Installed skill dir exists but no venv → installer never ran or
-        # ran with an older install.sh that predates the venv bundling.
-        print(f"  Install script found but bundled venv is missing:")
-        print(f"    bash {install_sh}")
-        print("  This creates ~/.claude/skills/vulnhunter-fix/.venv/ and")
+        print("  If that still fails, rebuild the venv from your")
+        print("  vulnhunter-fix source checkout:")
+        print(run_install_hint)
+    elif skill_installed:
+        # Skill dir exists (SKILL.md present) but no venv → installer never
+        # ran, or ran with an older installer that predates venv bundling.
+        print("  Skill is installed but the bundled venv is missing.")
+        print("  From your vulnhunter-fix source checkout:")
+        print(run_install_hint)
+        print(f"  This creates {skill_dir}{os.sep}.venv{os.sep} and")
         print("  installs graphifyy + jsonschema into it.")
     else:
         # Not installed at all.
-        print("  No installed skill at ~/.claude/skills/vulnhunter-fix/.")
+        print(f"  No installed skill at {skill_dir}.")
         print("  From your vulnhunter-fix source checkout:")
-        print("    bash install.sh")
+        print(run_install_hint)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `install.cmd` / `uninstall.cmd` so Windows users can install/remove
  the skills without WSL or a POSIX shell (mirrors the existing
  `install.sh` / `uninstall.sh` behavior).
- Updates `vulnhunter-fix/scripts/_skill_bootstrap.py` to resolve the
  bundled venv's Windows layout (`.venv\Scripts\python.exe` and
  `.venv\Lib\site-packages`) instead of only checking the POSIX
  `.venv/bin/python3` path, so the interpreter/site-packages bootstrap
  works correctly on Windows.
- Documents the Windows install flow in the README.

## Test plan
- [x] Ran `install.cmd` on Windows (cmd.exe), confirmed it copies the
  skills into `%USERPROFILE%\.claude\skills\` and creates the
  `vulnhunter-fix` venv at `.venv\Scripts\python.exe` with
  `.venv\Lib\site-packages` populated.
- [x] Verified `_skill_bootstrap.py`'s Windows path branch matches the
  venv layout actually produced by the install.
- [x] Ran `uninstall.cmd` on Windows; completed without errors and
  removed the installed skills as expected.