### PR TITLE
Fix SyntaxError in vulnhunter-agent config (unclosed tuple breaks package import)

### DIFF
--- a/vulnhunter-agent/agent/config.py
+++ b/vulnhunter-agent/agent/config.py
@@ -780,6 +780,7 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
                 else []
             )
             if str(p).strip()
+        ),
         max_comment_pages=int(
             _resolve(verify_raw, "verify", "max_comment_pages", kind=int, default=20)
         ),

--- a/vulnhunter-agent/tests/test_config.py
+++ b/vulnhunter-agent/tests/test_config.py
@@ -414,6 +414,40 @@ allowed_tools = ["Read", "Edit"]
         assert cfg.publish.enabled is True
         assert cfg.publish.destination_repo == "https://github.com/example/results"
 
+    def test_verify_tuple_fields_parse_from_toml(self, tmp_path: Path) -> None:
+        # Regression: the [verify] list fields (allowed_clone_hosts,
+        # token_path_prefixes) are built from generator expressions inside
+        # tuple(...) calls in load_config. A missing close-paren on one of
+        # them is a module-level SyntaxError that breaks the whole agent
+        # package import — so this exercises those two fields end-to-end.
+        path = tmp_path / "cfg.toml"
+        path.write_text(
+            """
+[anthropic]
+bedrock_base_url = "https://b"
+model = "m"
+[oauth]
+token_endpoint = "https://o"
+client_id = "x"
+client_secret = "y"
+[verify]
+allowed_clone_hosts = ["git.internal.example", "  ", "ghe.example.com"]
+token_path_prefixes = ["my-org", "my-org/allowed-repo", ""]
+"""
+        )
+        cfg = load_config(path)
+        # Blank/whitespace-only entries are dropped; order preserved.
+        assert cfg.verify.allowed_clone_hosts == (
+            "git.internal.example",
+            "ghe.example.com",
+        )
+        assert cfg.verify.token_path_prefixes == (
+            "my-org",
+            "my-org/allowed-repo",
+        )
+        # And the downstream int bounds that follow the tuple fields still resolve.
+        assert cfg.verify.max_comment_pages == 20
+
 
 # ---------------------------------------------------------------------------
 # [logging] section


### PR DESCRIPTION
## What

`vulnhunter-agent/agent/config.py` has a module-level `SyntaxError` on `main`: the `token_path_prefixes=tuple(...)` generator expression inside `load_config()` is missing its closing paren before the next keyword argument (`max_comment_pages=int(...)`).

```
  File "vulnhunter-agent/agent/config.py", line 743
    verify = VerifyConfig(
                         ^
SyntaxError: '(' was never closed
```

## Impact

Because it's a syntax error at import time, `import agent.config` fails — which takes down the **entire** `vulnhunter-agent` package. The headless runtime agent can't start, and the test suite errors out at `conftest.py` import (0 tests run), so CI on the agent component can't go green.

## Fix

Add the single missing `)` that closes the `tuple(...)` call.

I also added a regression test (`tests/test_config.py::TestLoadConfig::test_verify_tuple_fields_parse_from_toml`) that loads a `[verify]` config exercising both tuple-built list fields (`allowed_clone_hosts`, `token_path_prefixes`) and the `max_comment_pages` int that immediately follows them. There was previously no test that parsed these fields from TOML, which is why the break shipped — the fields were only ever constructed with defaults. The new test would have caught it (as a collection failure) and now guards the block directly.

## Validation

```
cd vulnhunter-agent && pip install -e ".[dev]" && pytest -q
# 1109 passed, 1 skipped   (previously: collection error, 0 tests run)
```

Confirmed the new test fails (import/collection error) against the pre-fix `config.py` and passes after the one-character fix.