### PR TITLE
Add bedrock_sigv4 auth mode: call Bedrock directly with SigV4 (no proxy/bearer)

### DIFF
--- a/vulnhunter-agent/README.md
+++ b/vulnhunter-agent/README.md
@@ -65,9 +65,13 @@ Settings load from a TOML file (`--config`, then `$VULNHUNT_AGENT_CONFIG`, then
 |-------------|----------------------|-------------|
 | `api_key` *(default)* | Direct Anthropic API | `[anthropic].api_key` or the standard `ANTHROPIC_API_KEY` env var |
 | `bedrock_oauth` | Routes through an AWS Bedrock proxy fronted by an OAuth2 client-credentials token endpoint | `[anthropic].bedrock_base_url` + the `[oauth]` block (`token_endpoint`, `client_id`, `client_secret`) |
+| `bedrock_sigv4` | Calls Amazon Bedrock directly with SigV4 request signing via the standard AWS credential chain — no proxy, no bearer token | `[anthropic].aws_region`; optionally `aws_profile` (named profile) and `bedrock_base_url` (VPC/custom endpoint). No `[oauth]` block. |
 
 `bedrock_oauth` exists for environments that front Claude with a Bedrock proxy and mint
-short-lived bearer tokens; most users want the default `api_key` mode.
+short-lived bearer tokens. `bedrock_sigv4` is for AWS-native setups that call Bedrock
+directly (use a cross-region inference-profile model ID, e.g. `us.anthropic.claude-...`);
+credentials resolve from the usual AWS chain — env vars, shared config/credentials file,
+SSO, or an instance/task role. Most users want the default `api_key` mode.
 
 ### Other sections (abridged)
 
@@ -90,6 +94,7 @@ CLI (python -m agent)
   └─ config.load_config()            TOML + VULNHUNT_* env  → AgentConfig
   └─ make_token_manager(config)      api_key → ApiKeyTokenManager
                                      bedrock_oauth → OAuthTokenManager
+                                     bedrock_sigv4 → SigV4TokenManager
   └─ runner.run_vulnhunt()
         └─ build_claude_settings()   env (auth + proxy + telemetry) + sandbox JSON
         └─ Claude Agent SDK          runs /vulnhunt, streams events, retries on 429
@@ -101,11 +106,14 @@ CLI (python -m agent)
 
 - **Auth is a single chokepoint.** `build_claude_settings` renders the Claude Code
   settings JSON (environment + sandbox) and is the only place that knows whether to set
-  `ANTHROPIC_API_KEY` (api_key mode) or the Bedrock env + `ANTHROPIC_AUTH_TOKEN`
-  (bedrock_oauth mode). Both the scan loop and the issues-LLM calls go through it.
-- **Token providers share one interface.** `ApiKeyTokenManager` and `OAuthTokenManager`
-  both expose `get_valid_token()`; `make_token_manager(config)` returns the right one, so
-  the rest of the code is auth-mode agnostic.
+  `ANTHROPIC_API_KEY` (api_key mode), the Bedrock env + `ANTHROPIC_AUTH_TOKEN`
+  (bedrock_oauth mode), or the Bedrock env *without* any token (bedrock_sigv4 mode —
+  omitting `CLAUDE_CODE_SKIP_BEDROCK_AUTH` / `ANTHROPIC_AUTH_TOKEN` is what makes the
+  bundled CLI sign requests itself). Both the scan loop and the issues-LLM calls go
+  through it.
+- **Token providers share one interface.** `ApiKeyTokenManager`, `OAuthTokenManager`,
+  and `SigV4TokenManager` all expose `get_valid_token()`; `make_token_manager(config)`
+  returns the right one, so the rest of the code is auth-mode agnostic.
 - **Contracts are schema-validated.** `scan_manifest.schema.json` (agent → scan-worker)
   and `verify_disposition.schema.json` (verify output) are validated before write.
 - **The `vulnhunter` package** is the thin CLI entry point around the `agent` package.

--- a/vulnhunter-agent/agent/_llm.py
+++ b/vulnhunter-agent/agent/_llm.py
@@ -61,7 +61,7 @@ from tenacity import (
     wait_none,
 )
 
-from .auth import OAuthTokenManager
+from .auth import TokenProvider
 from .build_settings import build_claude_settings
 from .config import AgentConfig
 from ._transient import classify as _classify_transient, is_transient_status
@@ -386,7 +386,7 @@ async def call_json(
     system: str,
     user: str,
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     cost_tracker: CostStats | None = None,
     backoffs: tuple[float, ...] = _TRANSIENT_BACKOFFS,
     log_retries: bool = False,
@@ -480,7 +480,7 @@ async def call_json_with_fallback(
     system: str,
     user: str,
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     cost_tracker: CostStats | None = None,
     stage: str = "",
     backoffs: tuple[float, ...] = _TRANSIENT_BACKOFFS,

--- a/vulnhunter-agent/agent/auth.py
+++ b/vulnhunter-agent/agent/auth.py
@@ -1,6 +1,6 @@
 """Anthropic auth providers for the agent.
 
-Two token providers share a ``get_valid_token()`` interface so call sites
+Three token providers share a ``get_valid_token()`` interface so call sites
 don't care which auth mode is active:
 
 - ``ApiKeyTokenManager`` — direct Anthropic API. ``get_valid_token()``
@@ -9,6 +9,11 @@ don't care which auth mode is active:
   client_id + client_secret against the token endpoint, cache the access
   token, and refresh after a fraction of its declared lifetime. The bearer
   is forwarded to a Bedrock proxy as ANTHROPIC_AUTH_TOKEN.
+- ``SigV4TokenManager`` — Amazon Bedrock with SigV4 request signing. There
+  is no bearer token: the bundled Claude Code CLI signs each request with
+  the standard AWS credential chain (env vars, shared config/credentials,
+  SSO, container/instance role). ``get_valid_token()`` returns an empty
+  string so the shared call-site interface is preserved.
 
 ``make_token_manager(config)`` returns the right one for the configured
 ``anthropic.auth_mode``.
@@ -56,6 +61,25 @@ class ApiKeyTokenManager:
 
     def get_valid_token(self) -> str:
         return self._api_key
+
+
+class SigV4TokenManager:
+    """Token provider for Amazon Bedrock SigV4 auth.
+
+    No bearer token exists in this mode: the bundled Claude Code CLI signs
+    Bedrock requests with the standard AWS credential chain. This provider
+    exists only to satisfy the shared ``get_valid_token()`` interface, so
+    every call site (LLM calls, issues, verify) stays auth-mode agnostic.
+    Returns an empty string — ``build_settings`` deliberately omits
+    ``ANTHROPIC_AUTH_TOKEN`` for this mode, so the empty value is never
+    consumed as a credential.
+    """
+
+    def __init__(self, name: str = "vulnhunter"):
+        self._name = name
+
+    def get_valid_token(self) -> str:
+        return ""
 
 
 class OAuthTokenManager:
@@ -115,12 +139,15 @@ class OAuthTokenManager:
 
 def make_token_manager(
     config: AgentConfig, name: str = "vulnhunter"
-) -> ApiKeyTokenManager | OAuthTokenManager:
+) -> ApiKeyTokenManager | OAuthTokenManager | SigV4TokenManager:
     """Return the Anthropic token provider for the configured auth mode.
 
-    Both providers expose ``get_valid_token()``, so callers can use the
-    result without caring whether auth is API-key or Bedrock/OAuth.
+    All providers expose ``get_valid_token()``, so callers can use the
+    result without caring whether auth is API-key, Bedrock/OAuth, or
+    Bedrock/SigV4.
     """
     if config.anthropic.auth_mode == "bedrock_oauth":
         return OAuthTokenManager(config.oauth, config.tls, name=name)
+    if config.anthropic.auth_mode == "bedrock_sigv4":
+        return SigV4TokenManager(name=name)
     return ApiKeyTokenManager(config.anthropic.api_key, name=name)

--- a/vulnhunter-agent/agent/auth.py
+++ b/vulnhunter-agent/agent/auth.py
@@ -27,12 +27,23 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Protocol
 
 import httpx
 
 from .config import AgentConfig, OAuthConfig, TLSConfig
 
 logger = logging.getLogger(__name__)
+
+
+class TokenProvider(Protocol):
+    """The shared interface every auth-mode token manager implements.
+
+    Call sites annotate against this instead of a concrete manager so they
+    stay auth-mode agnostic (see ``make_token_manager``).
+    """
+
+    def get_valid_token(self) -> str: ...
 
 
 class AuthTokenError(RuntimeError):

--- a/vulnhunter-agent/agent/build_settings.py
+++ b/vulnhunter-agent/agent/build_settings.py
@@ -1,9 +1,11 @@
 """Build the Claude Code settings JSON the SDK passes through to the CLI.
 
-Routes Anthropic calls either directly to the Anthropic API (``api_key``
-mode) or through an AWS Bedrock proxy fronted by an OAuth bearer token
-(``bedrock_oauth`` mode), blanks out inherited HTTP proxies, applies an
-OS-level sandbox, and (optionally) enables OTLP telemetry.
+Routes Anthropic calls one of three ways: directly to the Anthropic API
+(``api_key`` mode), through an AWS Bedrock proxy fronted by an OAuth bearer
+token (``bedrock_oauth`` mode), or directly to Amazon Bedrock with SigV4
+request signing via the standard AWS credential chain (``bedrock_sigv4``
+mode). It also blanks out inherited HTTP proxies, applies an OS-level
+sandbox, and (optionally) enables OTLP telemetry.
 """
 
 from __future__ import annotations
@@ -45,12 +47,39 @@ def _anthropic_host(cfg: AgentConfig) -> str:
     """The network host the SDK talks to, for the sandbox allow-list."""
     if cfg.anthropic.auth_mode == "bedrock_oauth":
         return urlparse(cfg.anthropic.bedrock_base_url).hostname or ""
+    if cfg.anthropic.auth_mode == "bedrock_sigv4":
+        # Explicit base URL (VPC/custom endpoint) wins; otherwise the
+        # regional Bedrock runtime endpoint the CLI will call by default.
+        if cfg.anthropic.bedrock_base_url:
+            return urlparse(cfg.anthropic.bedrock_base_url).hostname or ""
+        region = cfg.anthropic.aws_region.strip()
+        return f"bedrock-runtime.{region}.amazonaws.com" if region else ""
     return "api.anthropic.com"
 
 
-def _build_sandbox(cfg: AgentConfig) -> dict:
+def _sandbox_allowed_domains(cfg: AgentConfig) -> list[str]:
+    """Hosts the sandboxed CLI is allowed to reach.
+
+    Always the Anthropic/Bedrock inference host. In ``bedrock_sigv4`` mode the
+    CLI also signs with the AWS credential chain, which for assume-role / SSO
+    credentials calls regional STS — so we add the regional STS endpoint too.
+    (Static-key credentials need no extra host; IMDS/instance-role uses the
+    link-local 169.254.169.254 address, and full SSO login flows may need
+    additional endpoints — for those, widen this list or disable the sandbox.)
+    """
     host = _anthropic_host(cfg)
-    allowed_domains = [host] if host else []
+    domains = [host] if host else []
+    if cfg.anthropic.auth_mode == "bedrock_sigv4":
+        region = cfg.anthropic.aws_region.strip()
+        if region:
+            sts = f"sts.{region}.amazonaws.com"
+            if sts not in domains:
+                domains.append(sts)
+    return domains
+
+
+def _build_sandbox(cfg: AgentConfig) -> dict:
+    allowed_domains = _sandbox_allowed_domains(cfg)
     return {
         "enabled": cfg.sandbox.enabled,
         "failIfUnavailable": cfg.sandbox.fail_if_unavailable,
@@ -104,6 +133,30 @@ def build_claude_settings(
                 "ENABLE_PROMPT_CACHING_1H_BEDROCK": "1",
             }
         )
+    elif cfg.anthropic.auth_mode == "bedrock_sigv4":
+        # Direct Amazon Bedrock with SigV4 signing. Crucially we set
+        # CLAUDE_CODE_USE_BEDROCK=1 but DELIBERATELY omit both
+        # CLAUDE_CODE_SKIP_BEDROCK_AUTH and ANTHROPIC_AUTH_TOKEN — their
+        # absence is what makes the bundled CLI sign requests with the AWS
+        # credential chain (env vars, shared config/credentials, SSO,
+        # container/instance role) instead of forwarding a bearer token to
+        # a proxy. auth_token is empty in this mode (SigV4TokenManager).
+        env.update(
+            {
+                "CLAUDE_CODE_USE_BEDROCK": "1",
+                "AWS_REGION": cfg.anthropic.aws_region,
+                # Same 1-hour cache-TTL rationale as bedrock_oauth.
+                "ENABLE_PROMPT_CACHING_1H_BEDROCK": "1",
+            }
+        )
+        # Optional explicit endpoint (VPC / custom Bedrock endpoint). Blank →
+        # the CLI derives the regional bedrock-runtime endpoint from AWS_REGION.
+        if cfg.anthropic.bedrock_base_url:
+            env["ANTHROPIC_BEDROCK_BASE_URL"] = cfg.anthropic.bedrock_base_url
+        # Optional named profile from the shared AWS config/credentials file.
+        # Blank → default credential chain.
+        if cfg.anthropic.aws_profile:
+            env["AWS_PROFILE"] = cfg.anthropic.aws_profile
     else:
         # Direct Anthropic API. The API key rides in as auth_token (from the
         # token provider) or falls back to the configured value.

--- a/vulnhunter-agent/agent/build_settings.py
+++ b/vulnhunter-agent/agent/build_settings.py
@@ -11,6 +11,7 @@ sandbox, and (optionally) enables OTLP telemetry.
 from __future__ import annotations
 
 import json
+import os
 import re
 from urllib.parse import urlparse
 
@@ -52,9 +53,26 @@ def _anthropic_host(cfg: AgentConfig) -> str:
         # regional Bedrock runtime endpoint the CLI will call by default.
         if cfg.anthropic.bedrock_base_url:
             return urlparse(cfg.anthropic.bedrock_base_url).hostname or ""
-        region = cfg.anthropic.aws_region.strip()
+        region = cfg.anthropic.aws_region
         return f"bedrock-runtime.{region}.amazonaws.com" if region else ""
     return "api.anthropic.com"
+
+
+def _sandbox_allow_read_paths(cfg: AgentConfig) -> list[str]:
+    """Paths the sandboxed CLI may read.
+
+    Always the cwd (the cloned repo). In ``bedrock_sigv4`` mode also the
+    shared AWS config directory (``~/.aws`` — config, credentials, and the
+    SSO token cache): on Linux, home directories sit under the denied
+    ``/home`` / ``/root`` prefixes, so without this carve-out the credential
+    chain degrades to env-var credentials only and ``aws_profile`` / SSO
+    silently stop working. The allow entry is more specific than the deny
+    prefix, so it wins; it is read-only (``allowWrite`` is untouched).
+    """
+    paths = list(_SANDBOX_ALLOW_READ_PATHS)
+    if cfg.anthropic.auth_mode == "bedrock_sigv4":
+        paths.append(os.path.expanduser("~/.aws"))
+    return paths
 
 
 def _sandbox_allowed_domains(cfg: AgentConfig) -> list[str]:
@@ -70,7 +88,7 @@ def _sandbox_allowed_domains(cfg: AgentConfig) -> list[str]:
     host = _anthropic_host(cfg)
     domains = [host] if host else []
     if cfg.anthropic.auth_mode == "bedrock_sigv4":
-        region = cfg.anthropic.aws_region.strip()
+        region = cfg.anthropic.aws_region
         if region:
             sts = f"sts.{region}.amazonaws.com"
             if sts not in domains:
@@ -86,7 +104,7 @@ def _build_sandbox(cfg: AgentConfig) -> dict:
         "allowUnsandboxedCommands": cfg.sandbox.allow_unsandboxed_commands,
         "filesystem": {
             "denyRead": list(_SANDBOX_DENY_READ_PATHS),
-            "allowRead": list(_SANDBOX_ALLOW_READ_PATHS),
+            "allowRead": _sandbox_allow_read_paths(cfg),
             "denyWrite": list(_SANDBOX_DENY_WRITE_PATHS),
             "allowWrite": list(_SANDBOX_ALLOW_WRITE_PATHS),
         },

--- a/vulnhunter-agent/agent/config.example.toml
+++ b/vulnhunter-agent/agent/config.example.toml
@@ -22,6 +22,14 @@
 #   "bedrock_oauth" — route through an AWS Bedrock proxy fronted by an OAuth2
 #                     client-credentials endpoint. Requires bedrock_base_url
 #                     and the [oauth] block.
+#   "bedrock_sigv4" — call Amazon Bedrock directly with SigV4 request signing
+#                     via the standard AWS credential chain (env vars, shared
+#                     config/credentials file, SSO, container/instance role).
+#                     No proxy, no bearer token, no [oauth] block. Requires
+#                     aws_region; bedrock_base_url is optional (blank → the
+#                     regional bedrock-runtime endpoint). Set aws_profile to
+#                     pick a named profile. Use cross-region inference-profile
+#                     model IDs as the model (e.g. "us.anthropic.claude-...").
 auth_mode = "api_key"
 api_key = ""
 # Default model. Override per-invocation with --model.
@@ -29,8 +37,12 @@ model = "claude-opus-4-8"
 
 # --- bedrock_oauth mode only (leave blank for api_key mode) ---
 # Base URL of the proxy that fronts Bedrock-hosted Claude.
+# --- bedrock_sigv4 mode: leave bedrock_base_url blank for the regional
+#     endpoint, or set it for a VPC/custom Bedrock endpoint. ---
 bedrock_base_url = ""
 aws_region = "us-east-1"
+# bedrock_sigv4 mode only: optional named AWS profile. Blank → default chain.
+aws_profile = ""
 
 [oauth]
 # bedrock_oauth mode only: OAuth2 client-credentials endpoint that mints the

--- a/vulnhunter-agent/agent/config.example.toml
+++ b/vulnhunter-agent/agent/config.example.toml
@@ -30,6 +30,12 @@
 #                     regional bedrock-runtime endpoint). Set aws_profile to
 #                     pick a named profile. Use cross-region inference-profile
 #                     model IDs as the model (e.g. "us.anthropic.claude-...").
+#                     With [sandbox].enabled = true, env-var / profile / SSO
+#                     credentials work (~/.aws is made readable and regional
+#                     STS is allow-listed), but IMDS/ECS metadata-endpoint
+#                     credentials (instance/task roles) are NOT reachable —
+#                     widen the sandbox network allow-list or disable the
+#                     sandbox for those.
 auth_mode = "api_key"
 api_key = ""
 # Default model. Override per-invocation with --model.

--- a/vulnhunter-agent/agent/config.py
+++ b/vulnhunter-agent/agent/config.py
@@ -37,11 +37,23 @@ class AnthropicConfig:
     #   "bedrock_oauth" — route through an AWS Bedrock proxy fronted by an
     #                     OAuth2 client-credentials token endpoint. Requires
     #                     bedrock_base_url and the [oauth] block.
+    #   "bedrock_sigv4" — call Amazon Bedrock directly with SigV4 request
+    #                     signing. The bundled Claude Code CLI signs requests
+    #                     with the standard AWS credential chain (env vars,
+    #                     shared config/credentials file, SSO, container/IMDS
+    #                     role) — no proxy, no bearer token, no OAuth block.
+    #                     Set aws_region (and optionally aws_profile). Leave
+    #                     bedrock_base_url blank to use the regional Bedrock
+    #                     runtime endpoint, or set it for a VPC/custom endpoint.
     model: str
     auth_mode: str = "api_key"
     api_key: str = ""
     bedrock_base_url: str = ""
     aws_region: str = "us-east-1"
+    # bedrock_sigv4 mode only: optional named AWS profile from the shared
+    # config/credentials file. Blank → the CLI uses the default credential
+    # chain (AWS_* env vars, default profile, SSO, container/instance role).
+    aws_profile: str = ""
 
 
 @dataclass(frozen=True)
@@ -414,10 +426,10 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
         .strip()
         .lower()
     )
-    if auth_mode not in ("api_key", "bedrock_oauth"):
+    if auth_mode not in ("api_key", "bedrock_oauth", "bedrock_sigv4"):
         raise ValueError(
-            "anthropic.auth_mode must be 'api_key' or 'bedrock_oauth', "
-            f"got '{auth_mode}'"
+            "anthropic.auth_mode must be 'api_key', 'bedrock_oauth', or "
+            f"'bedrock_sigv4', got '{auth_mode}'"
         )
     # api_key resolves from [anthropic].api_key / VULNHUNT_ANTHROPIC_API_KEY,
     # falling back to the standard ANTHROPIC_API_KEY env var.
@@ -434,10 +446,19 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
         aws_region=str(
             _resolve(anthropic_raw, "anthropic", "aws_region", default="us-east-1")
         ),
+        aws_profile=str(
+            _resolve(anthropic_raw, "anthropic", "aws_profile", default="")
+        ).strip(),
     )
     if auth_mode == "bedrock_oauth" and not anthropic.bedrock_base_url:
         raise ValueError(
             "anthropic.auth_mode='bedrock_oauth' requires anthropic.bedrock_base_url"
+        )
+    # bedrock_sigv4 needs a region to build the endpoint / sign requests, but
+    # bedrock_base_url is optional (blank → regional Bedrock runtime endpoint).
+    if auth_mode == "bedrock_sigv4" and not anthropic.aws_region.strip():
+        raise ValueError(
+            "anthropic.auth_mode='bedrock_sigv4' requires anthropic.aws_region"
         )
 
     oauth = OAuthConfig(

--- a/vulnhunter-agent/agent/config.py
+++ b/vulnhunter-agent/agent/config.py
@@ -45,6 +45,14 @@ class AnthropicConfig:
     #                     Set aws_region (and optionally aws_profile). Leave
     #                     bedrock_base_url blank to use the regional Bedrock
     #                     runtime endpoint, or set it for a VPC/custom endpoint.
+    #                     Sandbox caveat: with [sandbox].enabled = true, the
+    #                     sandbox allow-lists Bedrock + regional STS and makes
+    #                     ~/.aws readable, so env-var, profile, and SSO-cached
+    #                     credentials work — but the link-local metadata
+    #                     endpoints (IMDS 169.254.169.254, ECS 169.254.170.2)
+    #                     are not allow-listed, so container/instance-role
+    #                     credentials require widening the sandbox network
+    #                     allow-list or disabling the sandbox.
     model: str
     auth_mode: str = "api_key"
     api_key: str = ""
@@ -445,7 +453,7 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
         ).strip(),
         aws_region=str(
             _resolve(anthropic_raw, "anthropic", "aws_region", default="us-east-1")
-        ),
+        ).strip(),
         aws_profile=str(
             _resolve(anthropic_raw, "anthropic", "aws_profile", default="")
         ).strip(),
@@ -456,7 +464,7 @@ def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig:
         )
     # bedrock_sigv4 needs a region to build the endpoint / sign requests, but
     # bedrock_base_url is optional (blank → regional Bedrock runtime endpoint).
-    if auth_mode == "bedrock_sigv4" and not anthropic.aws_region.strip():
+    if auth_mode == "bedrock_sigv4" and not anthropic.aws_region:
         raise ValueError(
             "anthropic.auth_mode='bedrock_sigv4' requires anthropic.aws_region"
         )

--- a/vulnhunter-agent/agent/issues.py
+++ b/vulnhunter-agent/agent/issues.py
@@ -22,7 +22,7 @@ from . import audit_extract as _audit_extract
 from . import issues_dedup, issues_extract, issues_fetch, issues_render, skill_version
 from ._github import api_base, extract_timestamp, parse_owner_repo
 from ._llm import CostStats
-from .auth import OAuthTokenManager, resolve_verify
+from .auth import TokenProvider, resolve_verify
 from .config import AgentConfig
 from .issues_extract import ExtractedReport, Finding
 from .issues_render import CleanScanContext
@@ -859,7 +859,7 @@ async def post_issues(
     report_url: str,
     target_repo_url: str,
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     audit_writer: "_audit.AuditWriter | None" = None,
     audit_report_id: str = "",
     audit_repo_slug: str = "",

--- a/vulnhunter-agent/agent/issues_dedup.py
+++ b/vulnhunter-agent/agent/issues_dedup.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from . import _llm
-from .auth import OAuthTokenManager
+from .auth import TokenProvider
 from .config import AgentConfig
 from .issues_extract import Finding
 from .issues_fetch import OpenIssue
@@ -227,7 +227,7 @@ async def _semantic_pass(
     findings: list[Finding],
     open_issues: list[OpenIssue],
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     *,
     cost_tracker: "_llm.CostStats | None" = None,
     audit_writer: "AuditWriter | None" = None,
@@ -340,7 +340,7 @@ async def dedup(
     findings: list[Finding],
     open_issues: list[OpenIssue],
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     *,
     cost_tracker: "_llm.CostStats | None" = None,
     audit_writer: "AuditWriter | None" = None,

--- a/vulnhunter-agent/agent/issues_extract.py
+++ b/vulnhunter-agent/agent/issues_extract.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from . import _llm
-from .auth import OAuthTokenManager
+from .auth import TokenProvider
 from .config import AgentConfig
 
 if TYPE_CHECKING:
@@ -182,7 +182,7 @@ def _coerce_finding(raw: dict[str, Any], files: dict[str, dict[str, str]]) -> Fi
 async def extract_findings(
     results_dir: Path,
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     *,
     cost_tracker: "_llm.CostStats | None" = None,
     audit_writer: "AuditWriter | None" = None,

--- a/vulnhunter-agent/agent/verify.py
+++ b/vulnhunter-agent/agent/verify.py
@@ -52,7 +52,7 @@ from ._github_verify import (
     UserContentEdit,
     make_client,
 )
-from .auth import make_token_manager, resolve_verify
+from .auth import TokenProvider, make_token_manager, resolve_verify
 from .config import AgentConfig
 from . import audit as _audit
 from .repo_properties import RepoProperties
@@ -785,7 +785,7 @@ def _make_run_id(records: list[_FetchedRecord]) -> str:
 async def _run_skill(
     *,
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     run_dir: Path,
     log_path: Path,
     target_repo: Path,

--- a/vulnhunter-agent/agent/verify_refs.py
+++ b/vulnhunter-agent/agent/verify_refs.py
@@ -43,7 +43,7 @@ import logging
 from typing import Any
 
 from . import _llm
-from .auth import OAuthTokenManager
+from .auth import TokenProvider
 from .config import AgentConfig
 
 logger = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ async def extract_cross_repo_references(
     comments_text: str,
     *,
     config: AgentConfig,
-    token_manager: OAuthTokenManager,
+    token_manager: TokenProvider,
     cost_tracker: "_llm.CostStats | None" = None,
 ) -> list[dict[str, str]]:
     """Run Haiku (Sonnet fallback) over ``comments_text`` and return the

--- a/vulnhunter-agent/tests/test_auth.py
+++ b/vulnhunter-agent/tests/test_auth.py
@@ -11,8 +11,15 @@ import pytest
 import respx
 
 from agent import auth as auth_mod
-from agent.auth import AuthTokenError, OAuthTokenManager, resolve_verify
-from agent.config import OAuthConfig, TLSConfig
+from agent.auth import (
+    ApiKeyTokenManager,
+    AuthTokenError,
+    OAuthTokenManager,
+    SigV4TokenManager,
+    make_token_manager,
+    resolve_verify,
+)
+from agent.config import AnthropicConfig, OAuthConfig, TLSConfig
 
 
 def _oauth_cfg(**overrides: object) -> OAuthConfig:
@@ -214,3 +221,51 @@ class TestOAuthTokenManager:
             token_manager.get_valid_token()
         for record in caplog.records:
             assert "super-secret-token" not in record.getMessage()
+
+
+# ---------------------------------------------------------------------------
+# SigV4TokenManager + make_token_manager dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSigV4TokenManager:
+    def test_returns_empty_token(self) -> None:
+        # No bearer exists in SigV4 mode — the CLI signs with the AWS chain.
+        assert SigV4TokenManager().get_valid_token() == ""
+
+    def test_no_network_calls(self) -> None:
+        # Deterministic + offline: get_valid_token must not touch httpx.
+        mgr = SigV4TokenManager(name="probe")
+        assert mgr.get_valid_token() == ""
+
+
+class TestMakeTokenManager:
+    def _anthropic(self, **overrides: object) -> AnthropicConfig:
+        base = dict(model="m", auth_mode="api_key")
+        base.update(overrides)
+        return AnthropicConfig(**base)  # type: ignore[arg-type]
+
+    def test_sigv4_mode_returns_sigv4_manager(
+        self, agent_config
+    ) -> None:
+        cfg = agent_config(
+            anthropic=self._anthropic(
+                auth_mode="bedrock_sigv4", aws_region="us-east-1"
+            )
+        )
+        assert isinstance(make_token_manager(cfg), SigV4TokenManager)
+
+    def test_oauth_mode_returns_oauth_manager(self, agent_config) -> None:
+        cfg = agent_config(
+            anthropic=self._anthropic(
+                auth_mode="bedrock_oauth",
+                bedrock_base_url="https://b.example.com",
+            )
+        )
+        assert isinstance(make_token_manager(cfg), OAuthTokenManager)
+
+    def test_api_key_mode_returns_api_key_manager(self, agent_config) -> None:
+        cfg = agent_config(
+            anthropic=self._anthropic(auth_mode="api_key", api_key="sk-x")
+        )
+        assert isinstance(make_token_manager(cfg), ApiKeyTokenManager)

--- a/vulnhunter-agent/tests/test_auth.py
+++ b/vulnhunter-agent/tests/test_auth.py
@@ -233,10 +233,15 @@ class TestSigV4TokenManager:
         # No bearer exists in SigV4 mode — the CLI signs with the AWS chain.
         assert SigV4TokenManager().get_valid_token() == ""
 
+    @respx.mock
     def test_no_network_calls(self) -> None:
         # Deterministic + offline: get_valid_token must not touch httpx.
+        # respx.mock with no routes registered raises on ANY outbound
+        # httpx request; the explicit zero-calls assert makes the
+        # contract visible either way.
         mgr = SigV4TokenManager(name="probe")
         assert mgr.get_valid_token() == ""
+        assert len(respx.calls) == 0
 
 
 class TestMakeTokenManager:

--- a/vulnhunter-agent/tests/test_build_settings.py
+++ b/vulnhunter-agent/tests/test_build_settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Callable
 
 import pytest
@@ -107,6 +108,41 @@ class TestBuildSandbox:
         assert "bedrock.vpce.example.com" in domains
         # STS still allowed for credential resolution in the region.
         assert "sts.us-west-2.amazonaws.com" in domains
+
+    def test_sigv4_allows_reading_aws_config_dir(
+        self, agent_config: Callable[..., AgentConfig]
+    ) -> None:
+        # The deny-read list covers /home and /root, which on Linux hides
+        # ~/.aws (config, credentials, SSO cache) and would silently reduce
+        # the credential chain to env vars only. SigV4 mode must carve out
+        # a read-only allow for ~/.aws so aws_profile / SSO work sandboxed.
+        cfg = agent_config(
+            anthropic=AnthropicConfig(
+                model="us.anthropic.claude-opus-4-8",
+                auth_mode="bedrock_sigv4",
+                aws_region="us-east-1",
+            )
+        )
+        fs = _build_sandbox(cfg)["filesystem"]
+        assert os.path.expanduser("~/.aws") in fs["allowRead"]
+        # Read-only: the write allow-list is untouched.
+        assert fs["allowWrite"] == ["."]
+
+    def test_non_sigv4_modes_do_not_expose_aws_config_dir(
+        self, agent_config: Callable[..., AgentConfig]
+    ) -> None:
+        for anthropic in (
+            AnthropicConfig(model="m", auth_mode="api_key", api_key="sk-test"),
+            AnthropicConfig(
+                model="m",
+                auth_mode="bedrock_oauth",
+                bedrock_base_url="https://bedrock.example.com",
+                aws_region="us-east-1",
+            ),
+        ):
+            cfg = agent_config(anthropic=anthropic)
+            fs = _build_sandbox(cfg)["filesystem"]
+            assert os.path.expanduser("~/.aws") not in fs["allowRead"]
 
 
 # ---------------------------------------------------------------------------

--- a/vulnhunter-agent/tests/test_build_settings.py
+++ b/vulnhunter-agent/tests/test_build_settings.py
@@ -78,6 +78,36 @@ class TestBuildSandbox:
         sandbox = _build_sandbox(cfg)
         assert sandbox["network"]["allowedDomains"] == []
 
+    def test_sigv4_default_endpoint_allows_regional_bedrock_and_sts(
+        self, agent_config: Callable[..., AgentConfig]
+    ) -> None:
+        cfg = agent_config(
+            anthropic=AnthropicConfig(
+                model="us.anthropic.claude-opus-4-8",
+                auth_mode="bedrock_sigv4",
+                aws_region="us-east-1",
+            )
+        )
+        domains = _build_sandbox(cfg)["network"]["allowedDomains"]
+        assert "bedrock-runtime.us-east-1.amazonaws.com" in domains
+        assert "sts.us-east-1.amazonaws.com" in domains
+
+    def test_sigv4_explicit_endpoint_wins_for_bedrock_host(
+        self, agent_config: Callable[..., AgentConfig]
+    ) -> None:
+        cfg = agent_config(
+            anthropic=AnthropicConfig(
+                model="us.anthropic.claude-opus-4-8",
+                auth_mode="bedrock_sigv4",
+                aws_region="us-west-2",
+                bedrock_base_url="https://bedrock.vpce.example.com",
+            )
+        )
+        domains = _build_sandbox(cfg)["network"]["allowedDomains"]
+        assert "bedrock.vpce.example.com" in domains
+        # STS still allowed for credential resolution in the region.
+        assert "sts.us-west-2.amazonaws.com" in domains
+
 
 # ---------------------------------------------------------------------------
 # build_claude_settings
@@ -240,6 +270,51 @@ class TestBuildClaudeSettings:
         )
         env = json.loads(build_claude_settings(cfg, "sk-passed", model="claude-opus-4-8"))["env"]
         assert env["ANTHROPIC_API_KEY"] == "sk-passed"
+
+    def test_sigv4_sets_bedrock_but_omits_bearer_and_skip_auth(
+        self, agent_config: Callable[..., AgentConfig]
+    ) -> None:
+        # The core SigV4 contract: Bedrock on, region set, prompt caching on,
+        # and — critically — NO bearer token and NO skip-auth flag, so the CLI
+        # falls through to AWS SigV4 signing.
+        cfg = agent_config(
+            anthropic=AnthropicConfig(
+                model="us.anthropic.claude-opus-4-8",
+                auth_mode="bedrock_sigv4",
+                aws_region="us-east-1",
+            )
+        )
+        env = json.loads(
+            build_claude_settings(cfg, "", model="us.anthropic.claude-opus-4-8")
+        )["env"]
+        assert env["CLAUDE_CODE_USE_BEDROCK"] == "1"
+        assert env["AWS_REGION"] == "us-east-1"
+        assert env["ENABLE_PROMPT_CACHING_1H_BEDROCK"] == "1"
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+        assert "CLAUDE_CODE_SKIP_BEDROCK_AUTH" not in env
+        assert "ANTHROPIC_API_KEY" not in env
+        # No explicit endpoint / profile → those keys are omitted.
+        assert "ANTHROPIC_BEDROCK_BASE_URL" not in env
+        assert "AWS_PROFILE" not in env
+
+    def test_sigv4_sets_profile_and_endpoint_when_configured(
+        self, agent_config: Callable[..., AgentConfig]
+    ) -> None:
+        cfg = agent_config(
+            anthropic=AnthropicConfig(
+                model="us.anthropic.claude-opus-4-8",
+                auth_mode="bedrock_sigv4",
+                aws_region="us-west-2",
+                aws_profile="vulnhunter",
+                bedrock_base_url="https://bedrock.vpce.example.com",
+            )
+        )
+        env = json.loads(
+            build_claude_settings(cfg, "", model="us.anthropic.claude-opus-4-8")
+        )["env"]
+        assert env["AWS_PROFILE"] == "vulnhunter"
+        assert env["ANTHROPIC_BEDROCK_BASE_URL"] == "https://bedrock.vpce.example.com"
+        assert env["AWS_REGION"] == "us-west-2"
 
 
 # ---------------------------------------------------------------------------

--- a/vulnhunter-agent/tests/test_config.py
+++ b/vulnhunter-agent/tests/test_config.py
@@ -447,6 +447,21 @@ bedrock_base_url = "https://bedrock.vpce.example.com"
         assert cfg.anthropic.aws_profile == "vulnhunter"
         assert cfg.anthropic.bedrock_base_url == "https://bedrock.vpce.example.com"
 
+    def test_aws_region_stripped_at_load(self, tmp_path: Path) -> None:
+        # A padded region ("  us-east-1  ") must be normalized at load so
+        # AWS_REGION and the sandbox allow-list never see the raw value.
+        path = tmp_path / "cfg.toml"
+        path.write_text(
+            """
+[anthropic]
+auth_mode = "bedrock_sigv4"
+model = "us.anthropic.claude-opus-4-8"
+aws_region = "  us-east-1  "
+"""
+        )
+        cfg = load_config(path)
+        assert cfg.anthropic.aws_region == "us-east-1"
+
     def test_bedrock_sigv4_blank_region_raises(self, tmp_path: Path) -> None:
         path = tmp_path / "cfg.toml"
         path.write_text(

--- a/vulnhunter-agent/tests/test_config.py
+++ b/vulnhunter-agent/tests/test_config.py
@@ -414,6 +414,78 @@ allowed_tools = ["Read", "Edit"]
         assert cfg.publish.enabled is True
         assert cfg.publish.destination_repo == "https://github.com/example/results"
 
+    def test_bedrock_sigv4_minimal(self, tmp_path: Path) -> None:
+        # SigV4 mode needs only a region; no [oauth] block, no bedrock_base_url.
+        path = tmp_path / "cfg.toml"
+        path.write_text(
+            """
+[anthropic]
+auth_mode = "bedrock_sigv4"
+model = "us.anthropic.claude-opus-4-8"
+aws_region = "us-east-1"
+"""
+        )
+        cfg = load_config(path)
+        assert cfg.anthropic.auth_mode == "bedrock_sigv4"
+        assert cfg.anthropic.aws_region == "us-east-1"
+        assert cfg.anthropic.bedrock_base_url == ""
+        assert cfg.anthropic.aws_profile == ""
+
+    def test_bedrock_sigv4_with_profile_and_endpoint(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        path.write_text(
+            """
+[anthropic]
+auth_mode = "bedrock_sigv4"
+model = "us.anthropic.claude-opus-4-8"
+aws_region = "us-west-2"
+aws_profile = "vulnhunter"
+bedrock_base_url = "https://bedrock.vpce.example.com"
+"""
+        )
+        cfg = load_config(path)
+        assert cfg.anthropic.aws_profile == "vulnhunter"
+        assert cfg.anthropic.bedrock_base_url == "https://bedrock.vpce.example.com"
+
+    def test_bedrock_sigv4_blank_region_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        path.write_text(
+            """
+[anthropic]
+auth_mode = "bedrock_sigv4"
+model = "m"
+aws_region = "   "
+"""
+        )
+        with pytest.raises(ValueError, match="aws_region"):
+            load_config(path)
+
+    def test_invalid_auth_mode_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        path.write_text(
+            """
+[anthropic]
+auth_mode = "bedrock_bogus"
+model = "m"
+"""
+        )
+        with pytest.raises(ValueError, match="auth_mode"):
+            load_config(path)
+
+    def test_bedrock_sigv4_profile_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VULNHUNT_ANTHROPIC_AUTH_MODE", "bedrock_sigv4")
+        monkeypatch.setenv("VULNHUNT_ANTHROPIC_MODEL", "us.anthropic.claude-opus-4-8")
+        monkeypatch.setenv("VULNHUNT_ANTHROPIC_AWS_REGION", "us-east-1")
+        monkeypatch.setenv("VULNHUNT_ANTHROPIC_AWS_PROFILE", "from-env")
+        from agent import config as cfg_mod
+
+        monkeypatch.setattr(cfg_mod, "_DEFAULT_CONFIG_FILENAME", "no-such.toml")
+        cfg = load_config()
+        assert cfg.anthropic.auth_mode == "bedrock_sigv4"
+        assert cfg.anthropic.aws_profile == "from-env"
+
     def test_verify_tuple_fields_parse_from_toml(self, tmp_path: Path) -> None:
         # Regression: the [verify] list fields (allowed_clone_hosts,
         # token_path_prefixes) are built from generator expressions inside


### PR DESCRIPTION
## Summary

Adds a third `anthropic.auth_mode` — **`bedrock_sigv4`** — that calls Amazon Bedrock directly using **SigV4 request signing via the standard AWS credential chain** (env vars, shared config/credentials file, SSO, container/instance role). No proxy, no bearer token, no `[oauth]` block.

Today the agent supports `api_key` (direct Anthropic API) and `bedrock_oauth` (Bedrock behind an OAuth2 client-credentials **proxy** that mints a bearer forwarded as `ANTHROPIC_AUTH_TOKEN`). Many AWS-native deployments don't have that proxy — they call Bedrock directly with SigV4 and cross-region inference profiles (e.g. `us.anthropic.claude-...`). This adds first-class support for that path.

> [!IMPORTANT]
> **Stacked on #13.** This branch includes the one-line `config.py` `SyntaxError` fix from #13 as its first commit (the config module doesn't import without it, so this feature can't be built or tested on top of a broken base). Please merge #13 first; GitHub will then automatically narrow this PR's diff to the single `bedrock_sigv4` commit. If you'd prefer, I can rebase once #13 lands.

## Design

No new dependencies (notably **no boto3**). The bundled Claude Code CLI already performs SigV4 signing itself when `CLAUDE_CODE_USE_BEDROCK=1` is set **and** the proxy variables are absent. So the feature is env plumbing:

- **`config.py`** — accept `auth_mode="bedrock_sigv4"`; add optional `AnthropicConfig.aws_profile`; require `aws_region` for the mode (`bedrock_base_url` stays optional → the regional `bedrock-runtime` endpoint).
- **`auth.py`** — `SigV4TokenManager.get_valid_token()` returns `""` (there is no bearer to mint; the CLI signs from the AWS chain). `make_token_manager` dispatches to it. Preserves the shared `get_valid_token()` interface so no call site changes.
- **`build_settings.py`** — a `bedrock_sigv4` env branch sets `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, and 1h prompt caching, and **deliberately omits** `CLAUDE_CODE_SKIP_BEDROCK_AUTH` and `ANTHROPIC_AUTH_TOKEN` — their absence is precisely what makes the CLI use SigV4 instead of a proxy bearer. Optional `AWS_PROFILE` / custom endpoint. The sandbox network allow-list gains the regional STS host so assume-role / SSO credential resolution isn't blocked when the sandbox is enabled.
- **`config.example.toml`** — documents the mode.

## Validation

```
cd vulnhunter-agent && pip install -e ".[dev]" && pytest -q
# 1123 passed, 1 skipped   (14 new tests across config / auth / build_settings)
```

New tests cover: mode parsing + `aws_region`/profile validation, env-var overrides, `SigV4TokenManager` (empty token, no network), `make_token_manager` dispatch, the sandbox allow-list (regional Bedrock + STS, explicit-endpoint override), and the core env contract (`USE_BEDROCK=1` present; `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_SKIP_BEDROCK_AUTH` / `ANTHROPIC_API_KEY` absent). Also verified end-to-end by loading a `bedrock_sigv4` config with a `us.anthropic.*` inference-profile model and asserting the rendered settings.