### PR TITLE
Add -- end-of-options separator to git fetch in harness clone

### DIFF
--- a/harness/local_harness/clone.py
+++ b/harness/local_harness/clone.py
@@ -7,15 +7,8 @@ import subprocess
 
 from .config import CLONE_BASE_DIR, CLONE_TIMEOUT
 
-_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 
-
-def _reject_option_like(value, what):
-    """Refuse a value that git would parse as an option (leading '-')."""
-    if value.startswith("-"):
-        raise RuntimeError(
-            f"refusing {what} that looks like a git option: {value!r}"
-        )
 
 
 def parse_source_url(source_code_url):
@@ -59,6 +52,13 @@ def clone_at_commit(repo_url, commit_hash, target_dir):
 
     Returns (target_dir, error_msg|None).
     """
+    if repo_url.startswith("-"):
+        return (target_dir, f"refusing repo URL that looks like a git option: {repo_url!r}")
+    if commit_hash.startswith("-"):
+        return (target_dir, f"refusing commit hash that looks like a git option: {commit_hash!r}")
+    if not _COMMIT_SHA_RE.match(commit_hash):
+        return (target_dir, f"commit must be a 7-40 char hex SHA, got {commit_hash!r}")
+
     if os.path.isdir(target_dir):
         if is_at_commit(target_dir, commit_hash):
             print(f"  [clone] Reusing existing clone at correct commit: {target_dir}")
@@ -66,11 +66,6 @@ def clone_at_commit(repo_url, commit_hash, target_dir):
         else:
             print(f"  [clone] Removing clone at wrong commit: {target_dir}")
             shutil.rmtree(target_dir)
-
-    _reject_option_like(repo_url, "repo URL")
-    _reject_option_like(commit_hash, "commit hash")
-    if not _COMMIT_SHA_RE.match(commit_hash):
-        raise ValueError(f"commit must be a 7-40 char hex SHA, got {commit_hash!r}")
 
     os.makedirs(CLONE_BASE_DIR, exist_ok=True)
 
@@ -117,7 +112,7 @@ def clone_at_commit(repo_url, commit_hash, target_dir):
             return (target_dir, error)
 
         checkout = subprocess.run(
-            ["git", "checkout", "--", commit_hash],
+            ["git", "checkout", commit_hash, "--"],
             capture_output=True, text=True, timeout=30, cwd=target_dir,
         )
         if checkout.returncode != 0:

--- a/harness/local_harness/clone.py
+++ b/harness/local_harness/clone.py
@@ -10,7 +10,6 @@ from .config import CLONE_BASE_DIR, CLONE_TIMEOUT
 _COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 
 
-
 def parse_source_url(source_code_url):
     """Parse a benchmark source_code URL into (repo_url, commit_hash).
 

--- a/harness/local_harness/clone.py
+++ b/harness/local_harness/clone.py
@@ -1,10 +1,21 @@
 """Clone repositories at specific commit hashes for benchmarking."""
 
 import os
+import re
 import shutil
 import subprocess
 
 from .config import CLONE_BASE_DIR, CLONE_TIMEOUT
+
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+def _reject_option_like(value, what):
+    """Refuse a value that git would parse as an option (leading '-')."""
+    if value.startswith("-"):
+        raise RuntimeError(
+            f"refusing {what} that looks like a git option: {value!r}"
+        )
 
 
 def parse_source_url(source_code_url):
@@ -55,6 +66,11 @@ def clone_at_commit(repo_url, commit_hash, target_dir):
         else:
             print(f"  [clone] Removing clone at wrong commit: {target_dir}")
             shutil.rmtree(target_dir)
+
+    _reject_option_like(repo_url, "repo URL")
+    _reject_option_like(commit_hash, "commit hash")
+    if not _COMMIT_SHA_RE.match(commit_hash):
+        raise ValueError(f"commit must be a 7-40 char hex SHA, got {commit_hash!r}")
 
     os.makedirs(CLONE_BASE_DIR, exist_ok=True)
 

--- a/harness/local_harness/clone.py
+++ b/harness/local_harness/clone.py
@@ -93,7 +93,7 @@ def clone_at_commit(repo_url, commit_hash, target_dir):
     print(f"  [clone] Fast fetch failed, falling back to full clone ...")
     try:
         result = subprocess.run(
-            ["git", "clone", repo_url, target_dir],
+            ["git", "clone", "--", repo_url, target_dir],
             capture_output=True, text=True, timeout=CLONE_TIMEOUT,
         )
         if result.returncode != 0:
@@ -101,7 +101,7 @@ def clone_at_commit(repo_url, commit_hash, target_dir):
             return (target_dir, error)
 
         checkout = subprocess.run(
-            ["git", "checkout", commit_hash],
+            ["git", "checkout", "--", commit_hash],
             capture_output=True, text=True, timeout=30, cwd=target_dir,
         )
         if checkout.returncode != 0:

--- a/harness/local_harness/clone.py
+++ b/harness/local_harness/clone.py
@@ -72,7 +72,7 @@ def clone_at_commit(repo_url, commit_hash, target_dir):
         )
         if init.returncode == 0 and remote.returncode == 0:
             result = subprocess.run(
-                ["git", "fetch", "--depth=1", "origin", commit_hash],
+                ["git", "fetch", "--depth=1", "--", "origin", commit_hash],
                 capture_output=True, text=True, timeout=CLONE_TIMEOUT, cwd=target_dir,
             )
             if result.returncode == 0:

--- a/harness/tests/test_clone.py
+++ b/harness/tests/test_clone.py
@@ -214,6 +214,56 @@ def test_clone_at_commit_wrong_commit_removed(monkeypatch, tmp_path):
     assert removed["r"] == target
 
 
+def test_clone_at_commit_fallback_checkout_argv(monkeypatch, tmp_path):
+    target = str(tmp_path / "clone")
+    isdir_seq = iter([False, False])
+    monkeypatch.setattr(clone.os.path, "isdir", lambda p: next(isdir_seq, False))
+    monkeypatch.setattr(clone.os, "makedirs", lambda *a, **k: None)
+
+    calls = []
+
+    def fake_run(cmd, **k):
+        calls.append(cmd)
+        if cmd[:2] == ["git", "fetch"]:
+            return _proc(1)
+        if cmd[:2] == ["git", "clone"]:
+            return _proc(0)
+        if cmd[:2] == ["git", "checkout"]:
+            return _proc(0)
+        return _proc(0)
+
+    monkeypatch.setattr(clone.subprocess, "run", fake_run)
+    clone.clone_at_commit("url", "abcdef12", target)
+    checkout_cmds = [c for c in calls if c[:2] == ["git", "checkout"]]
+    assert checkout_cmds[-1] == ["git", "checkout", "abcdef12", "--"]
+
+
+def test_clone_at_commit_option_like_url_rejected(tmp_path):
+    target = str(tmp_path / "clone")
+    _, err = clone.clone_at_commit("--upload-pack=evil", "abcdef12", target)
+    assert "git option" in err
+
+
+def test_clone_at_commit_option_like_commit_rejected(tmp_path):
+    target = str(tmp_path / "clone")
+    _, err = clone.clone_at_commit("url", "--exec=evil", target)
+    assert "git option" in err
+
+
+def test_clone_at_commit_non_sha_rejected(tmp_path):
+    target = str(tmp_path / "clone")
+    _, err = clone.clone_at_commit("url", "not-a-sha!", target)
+    assert "hex SHA" in err
+
+
+def test_clone_at_commit_uppercase_sha_accepted(monkeypatch, tmp_path):
+    target = str(tmp_path / "clone")
+    monkeypatch.setattr(clone.os.path, "isdir", lambda p: True)
+    monkeypatch.setattr(clone, "is_at_commit", lambda d, c: True)
+    _, err = clone.clone_at_commit("url", "ABCDEF12", target)
+    assert err is None
+
+
 def test_shallow_clone_reuse(monkeypatch, tmp_path):
     target = str(tmp_path / "c")
     monkeypatch.setattr(clone.os.path, "isdir", lambda p: True)

--- a/harness/tests/test_clone.py
+++ b/harness/tests/test_clone.py
@@ -67,7 +67,7 @@ def test_clone_at_commit_reuse_existing(monkeypatch, tmp_path):
     target = str(tmp_path / "clone")
     monkeypatch.setattr(clone.os.path, "isdir", lambda p: True)
     monkeypatch.setattr(clone, "is_at_commit", lambda d, c: True)
-    result_dir, err = clone.clone_at_commit("url", "abc", target)
+    result_dir, err = clone.clone_at_commit("url", "abcdef12", target)
     assert result_dir == target and err is None
 
 

--- a/harness/tests/test_clone.py
+++ b/harness/tests/test_clone.py
@@ -90,7 +90,7 @@ def test_clone_at_commit_fast_fetch_success(monkeypatch, tmp_path):
     monkeypatch.setattr(clone.subprocess, "run", fake_run)
     result_dir, err = clone.clone_at_commit("url", "abcdef12", target)
     assert err is None
-    assert ["git", "fetch", "--depth=1", "origin", "abcdef12"] in calls
+    assert ["git", "fetch", "--depth=1", "--", "origin", "abcdef12"] in calls
 
 
 def test_clone_at_commit_fast_fetch_timeout_then_full_clone(monkeypatch, tmp_path):


### PR DESCRIPTION
The agent-side `clone.py` already uses `--` separators in its git subprocess calls to guard against values that could be misinterpreted as flags. The harness-side `clone_at_commit()` passes the commit hash straight to `git fetch` without one. This brings the harness in line with the agent's existing defensive style.
