### PR TITLE
Add client_secret redaction pass to credential scrubber

### DIFF
--- a/vulnhunter-agent/agent/_url.py
+++ b/vulnhunter-agent/agent/_url.py
@@ -24,7 +24,7 @@ _RAW_TOKEN_RE = re.compile(
     r"(ghp_|gho_|ghu_|ghs_|ghr_|github_pat_|sk-ant-)[A-Za-z0-9_-]+"
 )
 _FORM_SECRET_RE = re.compile(
-    r"(?i)(client_secret\s*[=:]\s*)[^\s,}&\"']+"
+    r"(?i)(client[_-]?secret\"?\s*[=:]\s*)[\"']?[^\s,}&\"']+[\"']?"
 )
 
 

--- a/vulnhunter-agent/agent/_url.py
+++ b/vulnhunter-agent/agent/_url.py
@@ -23,6 +23,9 @@ _QUERY_TOKEN_RE = re.compile(r"(?i)([?&](?:access_token|token)=)([^&\s]+)")
 _RAW_TOKEN_RE = re.compile(
     r"(ghp_|gho_|ghu_|ghs_|ghr_|github_pat_|sk-ant-)[A-Za-z0-9_-]+"
 )
+_FORM_SECRET_RE = re.compile(
+    r"(?i)(client_secret\s*[=:]\s*)[^\s,}&\"']+"
+)
 
 
 def redact(text: str) -> str:
@@ -42,6 +45,7 @@ def redact(text: str) -> str:
     s = _BEARER_RE.sub(r"\1***", s)
     s = _QUERY_TOKEN_RE.sub(r"\1***", s)
     s = _RAW_TOKEN_RE.sub(r"\1***", s)
+    s = _FORM_SECRET_RE.sub(r"\1***", s)
     # Residual risk (VULN-012, CWE-532): redaction is pattern-based over
     # enumerated token formats; a novel/unknown secret format not in the pass
     # list above would still pass through to the audit stream.

--- a/vulnhunter-agent/agent/_url.py
+++ b/vulnhunter-agent/agent/_url.py
@@ -24,14 +24,15 @@ _RAW_TOKEN_RE = re.compile(
     r"(ghp_|gho_|ghu_|ghs_|ghr_|github_pat_|sk-ant-)[A-Za-z0-9_-]+"
 )
 _FORM_SECRET_RE = re.compile(
-    r"(?i)(client[_-]?secret\"?\s*[=:]\s*)[\"']?[^\s,}&\"']+[\"']?"
+    r"(?i)(client[_-]?secret[\"']?[ \t]*(?:\[\d+\])?[ \t]*[=:][ \t]*\[?[ \t]*)"
+    r"([\"']?)(?![\s\"'])([^\s,;}\]&\"'\[]+)\2"
 )
 
 
 def redact(text: str) -> str:
     """Mask credentials embedded in ``text`` before it is logged or audited.
 
-    Four passes (CWE-532) — ``text`` is treated as free-form audit content,
+    Five passes (CWE-532) — ``text`` is treated as free-form audit content,
     not just a URL:
 
     1. URL basic-auth (``://userinfo@``).
@@ -40,12 +41,14 @@ def redact(text: str) -> str:
     4. Known raw token prefixes (``ghp_``, ``gho_``, ``ghu_``, ``ghs_``,
        ``ghr_``, ``github_pat_``, ``sk-ant-``) — the prefix is preserved so
        the token kind stays identifiable while the secret body is masked.
+    5. ``client_secret`` values in form-encoded, JSON, and config formats
+       (``client_secret``, ``client-secret``, ``clientSecret``).
     """
     s = _BASIC_AUTH_RE.sub("://***@", text)
     s = _BEARER_RE.sub(r"\1***", s)
     s = _QUERY_TOKEN_RE.sub(r"\1***", s)
     s = _RAW_TOKEN_RE.sub(r"\1***", s)
-    s = _FORM_SECRET_RE.sub(r"\1***", s)
+    s = _FORM_SECRET_RE.sub(r"\1\2***\2", s)
     # Residual risk (VULN-012, CWE-532): redaction is pattern-based over
     # enumerated token formats; a novel/unknown secret format not in the pass
     # list above would still pass through to the audit stream.

--- a/vulnhunter-agent/tests/test_url.py
+++ b/vulnhunter-agent/tests/test_url.py
@@ -107,6 +107,30 @@ class TestRedact:
         url = "https://user:pass@github.com/owner/repo"
         assert redact(redact(url)) == redact(url)
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "client_secret=SUPERSECRET&grant_type=x",
+            "client_secret: SUPERSECRET",
+            "CLIENT_SECRET=SUPERSECRET",
+            '{"client_secret": "SUPERSECRET"}',
+            '{"client_secret":"SUPERSECRET"}',
+            'client_secret = "SUPERSECRET"',
+            "client_secret='SUPERSECRET'",
+            "client-secret=SUPERSECRET",
+            "clientSecret=SUPERSECRET",
+            "{'client_secret': 'SUPERSECRET'}",
+            '{"client_secret":["SUPERSECRET"]}',
+            "client_secret[0]=SUPERSECRET",
+            "client_secret=SUPERSECRET;grant_type=x",
+        ],
+    )
+    def test_client_secret_redacted(self, text: str) -> None:
+        out = redact(text)
+        assert "SUPERSECRET" not in out
+        assert "***" in out
+        assert redact(out) == out
+
     def test_handles_username_only(self) -> None:
         # The regex matches ://<no-@-or-/>+@.
         assert redact("https://user@github.com/o/r") == "https://***@github.com/o/r"

--- a/vulnhunter-agent/tests/verify_012_audit_redaction.py
+++ b/vulnhunter-agent/tests/verify_012_audit_redaction.py
@@ -5,6 +5,8 @@ audit content, but only rewrites basic-auth URLs. It must also redact bearer
 headers, access_token query params, and raw token prefixes.
 """
 
+import pytest
+
 from agent._url import redact
 
 
@@ -36,6 +38,27 @@ def test_raw_token_prefixes_redacted_prefix_preserved():
         out = redact(f"leaked token {prefix}{secret} in log")
         assert secret not in out, prefix
         assert prefix in out, f"prefix {prefix} should be preserved for triage"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "client_secret=SUPERSECRET&grant_type=x",
+        "client_secret: SUPERSECRET",
+        "CLIENT_SECRET=SUPERSECRET",
+        '{"client_secret": "SUPERSECRET"}',
+        '{"client_secret":"SUPERSECRET"}',
+        'client_secret = "SUPERSECRET"',
+        "client_secret='SUPERSECRET'",
+        "client-secret=SUPERSECRET",
+        "clientSecret=SUPERSECRET",
+    ],
+)
+def test_client_secret_redacted(text):
+    out = redact(text)
+    assert "SUPERSECRET" not in out
+    assert "***" in out
+    assert redact(out) == out  # idempotent
 
 
 def test_benign_text_unchanged():

--- a/vulnhunter-agent/tests/verify_012_audit_redaction.py
+++ b/vulnhunter-agent/tests/verify_012_audit_redaction.py
@@ -40,27 +40,6 @@ def test_raw_token_prefixes_redacted_prefix_preserved():
         assert prefix in out, f"prefix {prefix} should be preserved for triage"
 
 
-@pytest.mark.parametrize(
-    "text",
-    [
-        "client_secret=SUPERSECRET&grant_type=x",
-        "client_secret: SUPERSECRET",
-        "CLIENT_SECRET=SUPERSECRET",
-        '{"client_secret": "SUPERSECRET"}',
-        '{"client_secret":"SUPERSECRET"}',
-        'client_secret = "SUPERSECRET"',
-        "client_secret='SUPERSECRET'",
-        "client-secret=SUPERSECRET",
-        "clientSecret=SUPERSECRET",
-    ],
-)
-def test_client_secret_redacted(text):
-    out = redact(text)
-    assert "SUPERSECRET" not in out
-    assert "***" in out
-    assert redact(out) == out  # idempotent
-
-
 def test_benign_text_unchanged():
     assert redact("just a normal log line about issue #42") == (
         "just a normal log line about issue #42"


### PR DESCRIPTION
`redact()` handles URL basic-auth, Bearer headers, query-string tokens, and known token prefixes, but doesn't cover `client_secret` values. When the `bedrock_oauth` auth mode is in use, error responses from the token endpoint can include the client secret in form-encoded or header format, and those flow through to the audit stream unmasked.

This adds a regex pass for `client_secret` alongside the existing ones.
