### PR TITLE
Capture clone subprocess output to match rest of file

### DIFF
--- a/vulnhunter-agent/agent/clone.py
+++ b/vulnhunter-agent/agent/clone.py
@@ -111,12 +111,12 @@ def shallow_clone(
     if _GIT_EXECUTABLE is None:
         raise RuntimeError("git not on PATH; cannot clone")
     try:
-        # nosec B603 — argv is statically constructed ("clone --progress
-        # --depth 1 --"); effective_url comes from the agent's own URL
+        # nosec B603 — argv is statically constructed ("clone --depth 1
+        # --"); effective_url comes from the agent's own URL
         # validation + token injection; target is a Path the agent
         # owns. Absolute git path resolved at module load (kills B607).
         result = subprocess.run(  # nosec B603
-            [_GIT_EXECUTABLE, "clone", "--progress", "--depth", "1", "--", effective_url, str(target)],
+            [_GIT_EXECUTABLE, "clone", "--depth", "1", "--", effective_url, str(target)],
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
@@ -133,8 +133,8 @@ def shallow_clone(
         if target.exists():
             shutil.rmtree(target, ignore_errors=True)
         raise RuntimeError(
-            f"git clone failed (exit {result.returncode}) for {redact(repo_url)}; "
-            "see git output above"
+            f"git clone failed (exit {result.returncode}) for {redact(repo_url)}: "
+            f"{redact(result.stderr.strip())}"
         )
 
     # Strip the token from the remote URL stored in .git/config. Without

--- a/vulnhunter-agent/agent/clone.py
+++ b/vulnhunter-agent/agent/clone.py
@@ -117,6 +117,7 @@ def shallow_clone(
         # owns. Absolute git path resolved at module load (kills B607).
         result = subprocess.run(  # nosec B603
             [_GIT_EXECUTABLE, "clone", "--progress", "--depth", "1", "--", effective_url, str(target)],
+            capture_output=True,
             text=True,
             timeout=timeout_seconds,
             env=env,

--- a/vulnhunter-agent/agent/clone.py
+++ b/vulnhunter-agent/agent/clone.py
@@ -123,6 +123,10 @@ def shallow_clone(
             env=env,
         )
     except subprocess.TimeoutExpired as exc:
+        # On Windows with capture_output, grandchildren (git-remote-https,
+        # index-pack) can inherit the stderr pipe and keep it open after
+        # the direct child is killed, blocking the drain. A full fix
+        # requires Popen + process-tree kill; for now, accept the caveat.
         if target.exists():
             shutil.rmtree(target, ignore_errors=True)
         raise RuntimeError(
@@ -132,10 +136,15 @@ def shallow_clone(
     if result.returncode != 0:
         if target.exists():
             shutil.rmtree(target, ignore_errors=True)
+        _stderr = " ".join((result.stderr or "").split())[-2000:]
         raise RuntimeError(
             f"git clone failed (exit {result.returncode}) for {redact(repo_url)}: "
-            f"{redact(result.stderr.strip())}"
+            f"{redact(_stderr)}"
         )
+
+    if result.stderr and result.stderr.strip():
+        _warn = " ".join(result.stderr.split())[-2000:]
+        logger.debug("git clone stderr: %s", redact(_warn))
 
     # Strip the token from the remote URL stored in .git/config. Without
     # this, any subsequent `git remote get-url`, `git config -l`, or

--- a/vulnhunter-agent/tests/test_clone.py
+++ b/vulnhunter-agent/tests/test_clone.py
@@ -44,10 +44,10 @@ class TestDeriveRepoName:
 
 
 class _FakeCompleted:
-    def __init__(self, returncode: int = 0) -> None:
+    def __init__(self, returncode: int = 0, stderr: str = "") -> None:
         self.returncode = returncode
         self.stdout = ""
-        self.stderr = ""
+        self.stderr = stderr
 
 
 @pytest.fixture
@@ -142,11 +142,15 @@ class TestShallowClone:
         def fake_run(cmd: list[str], **kwargs: Any) -> _FakeCompleted:
             target = Path(cmd[-1])
             target.mkdir(parents=True, exist_ok=True)
-            return _FakeCompleted(returncode=128)
+            return _FakeCompleted(
+                returncode=128,
+                stderr="fatal: repository 'https://github.com/org/myrepo' not found",
+            )
 
         monkeypatch.setattr(clone_mod.subprocess, "run", fake_run)
-        with pytest.raises(RuntimeError, match="git clone failed"):
+        with pytest.raises(RuntimeError, match="git clone failed") as exc:
             shallow_clone("https://github.com/org/myrepo", tmp_path)
+        assert "repository" in str(exc.value)
         assert not (tmp_path / "myrepo").exists()
 
     def test_git_terminal_prompt_env_set(
@@ -244,6 +248,29 @@ class TestShallowClone:
         assert "secret" not in msg
         assert "***@github.com" in msg
 
+    def test_stderr_redacted_in_error_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fake_run(cmd: list[str], **kwargs: Any) -> _FakeCompleted:
+            target = Path(cmd[-1])
+            target.mkdir(parents=True, exist_ok=True)
+            return _FakeCompleted(
+                returncode=128,
+                stderr="fatal: Authentication failed for 'https://x-access-token:ghp_SECRET@github.com/org/repo'",
+            )
+
+        monkeypatch.setattr(clone_mod.subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError) as exc:
+            shallow_clone(
+                "https://github.com/org/repo",
+                tmp_path,
+            )
+        msg = str(exc.value)
+        assert "ghp_SECRET" not in msg
+        assert "Authentication failed" in msg
+
     def test_url_redacted_in_timeout_error_message(
         self,
         tmp_path: Path,
@@ -306,5 +333,7 @@ class TestShallowClone:
             "https://github.com/org/myrepo",
             tmp_path,
         )
-        assert captured[0][0] == "/usr/bin/git"
-        assert captured[0][1] == "clone"
+        assert captured[0] == [
+            "/usr/bin/git", "clone", "--depth", "1",
+            "--", "https://github.com/org/myrepo", str(tmp_path / "myrepo"),
+        ]

--- a/vulnhunter-agent/tests/test_clone.py
+++ b/vulnhunter-agent/tests/test_clone.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -337,3 +338,43 @@ class TestShallowClone:
             "/usr/bin/git", "clone", "--depth", "1",
             "--", "https://github.com/org/myrepo", str(tmp_path / "myrepo"),
         ]
+
+    def test_stderr_bounded_in_error_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        long_spam = "remote: spam\n" * 500
+        fatal = "fatal: repository 'https://github.com/org/myrepo' not found"
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> _FakeCompleted:
+            target = Path(cmd[-1])
+            target.mkdir(parents=True, exist_ok=True)
+            return _FakeCompleted(returncode=128, stderr=long_spam + fatal)
+
+        monkeypatch.setattr(clone_mod.subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError) as exc:
+            shallow_clone("https://github.com/org/myrepo", tmp_path)
+        msg = str(exc.value)
+        assert len(msg) <= 2200
+        assert "repository" in msg
+        assert "not found" in msg
+
+    def test_success_stderr_logged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        def fake_run(cmd: list[str], **kwargs: Any) -> _FakeCompleted:
+            target = Path(cmd[-1])
+            target.mkdir(parents=True, exist_ok=True)
+            return _FakeCompleted(
+                returncode=0,
+                stderr="warning: remote HEAD refers to nonexistent ref\n",
+            )
+
+        monkeypatch.setattr(clone_mod.subprocess, "run", fake_run)
+        with caplog.at_level(logging.DEBUG, logger="agent.clone"):
+            shallow_clone("https://github.com/org/myrepo", tmp_path)
+        assert any("remote HEAD" in r.message for r in caplog.records)


### PR DESCRIPTION
Every other subprocess call in `clone.py` (scrub, fetch, checkout) uses `capture_output=True`, but the main `git clone` call in `shallow_clone()` does not, its stderr goes straight to the parent process's file descriptors. This adds `capture_output=True` to match the rest of the file.

Also drops --progress from the clone argv. With capture_output=True, progress output goes to a pipe nobody reads, it just buffers counter spam into memory and dilutes the stderr used for error diagnostics.

