### PR TITLE
Port results-dir validation from verify_extract to issue_intake

### DIFF
--- a/vulnhunter-fix/scripts/issue_intake.py
+++ b/vulnhunter-fix/scripts/issue_intake.py
@@ -38,8 +38,11 @@ _RE_FINDING_ID = re.compile(
     r"<!--\s*vulnhunt-finding-id:\s*(VULN-\d{3})\s*-->", re.IGNORECASE
 )
 _RE_RESULTS_DIR = re.compile(
-    r"<!--\s*vulnhunt-results-dir:\s*([^\s<>]+)\s*-->", re.IGNORECASE
+    r"<!--\s*vulnhunt-results-dir:\s*"
+    r"([A-Za-z0-9._-]+_VULNHUNT_RESULTS_[0-9A-Za-z._-]+)\s*-->",
+    re.IGNORECASE,
 )
+_RESULTS_DIR_FORBIDDEN = ("..", "/", "\\")
 
 
 class MarkerExtractionError(ValueError):
@@ -76,10 +79,16 @@ def extract_markers(body: str, *, source_label: str = "issue body") -> Extracted
             f"{source_label}: missing required marker(s): {', '.join(missing)}"
         )
     assert m_key is not None and m_id is not None and m_dir is not None
+    results_dir = m_dir.group(1)
+    if any(tok in results_dir for tok in _RESULTS_DIR_FORBIDDEN):
+        raise MarkerExtractionError(
+            f"{source_label}: vulnhunt-results-dir contains a forbidden "
+            f"path token: {results_dir!r}"
+        )
     return ExtractedMarkers(
         vulnfix_key=m_key.group(1).lower(),
         finding_id=m_id.group(1).upper(),
-        results_dir=m_dir.group(1),
+        results_dir=results_dir,
     )
 
 

--- a/vulnhunter-fix/tests/test_issue_intake.py
+++ b/vulnhunter-fix/tests/test_issue_intake.py
@@ -126,7 +126,7 @@ class TestExtractMarkers:
         body = (
             "<!-- vulnfix-key: abcdef0123456789 -->\n"
             "<!-- vulnhunt-finding-id: VULN-7 -->\n"
-            "<!-- vulnhunt-results-dir: r -->\n"
+            "<!-- vulnhunt-results-dir: r_VULNHUNT_RESULTS_2026 -->\n"
         )
         with pytest.raises(MarkerExtractionError):
             extract_markers(body)
@@ -135,7 +135,7 @@ class TestExtractMarkers:
         body = (
             "<!-- vulnfix-key: notenoughh -->\n"
             "<!-- vulnhunt-finding-id: VULN-001 -->\n"
-            "<!-- vulnhunt-results-dir: r -->\n"
+            "<!-- vulnhunt-results-dir: r_VULNHUNT_RESULTS_2026 -->\n"
         )
         with pytest.raises(MarkerExtractionError):
             extract_markers(body)

--- a/vulnhunter-fix/tests/test_issue_intake.py
+++ b/vulnhunter-fix/tests/test_issue_intake.py
@@ -94,7 +94,7 @@ class TestExtractMarkers:
         body = (
             "<!--   vulnfix-key:    abcdef0123456789   -->\n"
             "<!--vulnhunt-finding-id: VULN-001-->\n"
-            "<!-- vulnhunt-results-dir: r -->\n"
+            "<!-- vulnhunt-results-dir: r_VULNHUNT_RESULTS_2026 -->\n"
         )
         assert extract_markers(body).vulnfix_key == "abcdef0123456789"
 
@@ -157,7 +157,7 @@ class TestExtractMarkers:
         # they're found even when scattered.
         body = (
             "Some narrative paragraph.\n\n"
-            "<!-- vulnhunt-results-dir: r -->\n\n"
+            "<!-- vulnhunt-results-dir: r_VULNHUNT_RESULTS_2026 -->\n\n"
             "More narrative.\n\n"
             "<!-- vulnfix-key: 0123456789abcdef -->\n\n"
             "Closing.\n\n"
@@ -166,6 +166,34 @@ class TestExtractMarkers:
         m = extract_markers(body)
         assert m.vulnfix_key == "0123456789abcdef"
         assert m.finding_id == "VULN-999"
+
+    @pytest.mark.parametrize(
+        "malicious",
+        [
+            "sess_../../../../var/tmp/pwn",
+            "x_VULNHUNT_RESULTS_../../evil",
+            "..x_VULNHUNT_RESULTS_2026",
+            "a/b_VULNHUNT_RESULTS_2026",
+            "a\\b_VULNHUNT_RESULTS_2026",
+        ],
+    )
+    def test_traversal_bearing_results_dir_is_rejected(self, malicious):
+        body = (
+            "<!-- vulnfix-key: 0123456789abcdef -->\n"
+            "<!-- vulnhunt-finding-id: VULN-001 -->\n"
+            f"<!-- vulnhunt-results-dir: {malicious} -->\n"
+        )
+        with pytest.raises(MarkerExtractionError):
+            extract_markers(body)
+
+    def test_results_dir_without_vulnhunt_results_rejected(self):
+        body = (
+            "<!-- vulnfix-key: 0123456789abcdef -->\n"
+            "<!-- vulnhunt-finding-id: VULN-001 -->\n"
+            "<!-- vulnhunt-results-dir: arbitrary-dirname -->\n"
+        )
+        with pytest.raises(MarkerExtractionError, match="vulnhunt-results-dir"):
+            extract_markers(body)
 
 
 # ---- reconstruct_original -------------------------------------------------


### PR DESCRIPTION
`verify_extract.py` validates the `vulnhunt-results-dir` marker with a structured regex (requiring the `_VULNHUNT_RESULTS_` naming convention) and rejects `..`, `/`, and `\` in the extracted value. `issue_intake.py` extracts the same marker but uses a permissive `[^\s<>]+` pattern with no forbidden-token check — looks like the validation was dropped when the code was ported to the fix engine.

This aligns `issue_intake.py` with `verify_extract.py` so both enforce the same constraints on the results directory name.

Updates two existing tests whose fixtures used bare directory names that no longer match the stricter pattern, and adds parametrized path-traversal rejection tests mirroring `verify_004`.
