### PR TITLE
ci: run all project tests on every PR via GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,10 @@ jobs:
       run:
         working-directory: ${{ matrix.project }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - harness
+          - vulnhunter-agent
+          - vulnhunter-fix
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run pytest
+        run: pytest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,34 +4,67 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pytest:
-    name: pytest (${{ matrix.project }})
+    name: pytest (${{ matrix.project }}, py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        project:
-          - harness
-          - vulnhunter-agent
-          - vulnhunter-fix
+        include:
+          - project: harness
+            python-version: "3.12"
+            extras: dev
+          - project: vulnhunter-agent
+            python-version: "3.12"
+            extras: dev
+          - project: vulnhunter-fix
+            python-version: "3.11"
+            extras: dev
+          - project: vulnhunter-fix
+            python-version: "3.12"
+            extras: dev
     defaults:
       run:
         working-directory: ${{ matrix.project }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install project with dev extras
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[${{ matrix.extras }}]"
 
-      - name: Run pytest
-        run: pytest -v
+      - name: Run pytest with coverage
+        run: |
+          pytest -v \
+            --cov \
+            --cov-report=term \
+            --cov-report=xml \
+            --junitxml=pytest-report.xml
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: pytest-${{ matrix.project }}-py${{ matrix.python-version }}
+          path: |
+            ${{ matrix.project }}/pytest-report.xml
+            ${{ matrix.project }}/coverage.xml
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tests.yml` — a `tests` workflow that runs pytest for each Python project on every PR and on pushes to `main`.
- Uses a `matrix` over `harness`, `vulnhunter-agent`, and `vulnhunter-fix`; each job installs its project with `[dev]` extras and runs `pytest` from that project's directory.
- `fail-fast: false` so a failure in one project doesn't hide failures in the others.
- Pinned to Python 3.12 (satisfies all three projects' `requires-python`).

## Test plan
- [ ] Confirm the `tests` workflow appears on this PR and all three matrix jobs run.
- [ ] Verify each job installs cleanly and executes its `tests/` suite.
- [ ] Confirm the workflow also runs on push to `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)